### PR TITLE
Adapt enumerable methods preference between find_all and select

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,8 +284,8 @@ community.
     end
     ```
     
-* Prefer **map** over *collect*, **find** over *detect*, **find_all** over
-  *select*, **size** over *length*. This is not a hard requirement; if the
+* Prefer **map** over *collect*, **find** over *detect*, **select** over
+  *find_all*, **size** over *length*. This is not a hard requirement; if the
   use of the alias enhances readability, it's ok to use it.
 
 ## Comments


### PR DESCRIPTION
I think most people use select over find_all.

As you said, this is clearly not written in stone, but as I pretty much agree with all the rest I figured out it may be worth mentioning and maybe changing.

As a popular example, Rails has 1395 select and 36 find_all (according to `ack --ruby -ch '\bselect\b'`).

I prefer select because it is a nice complement of reject (literally) and it is not composed of two words (which is a bit uncommon in core Ruby, except for each_*). Also, I tend to find it nicer in chains (find_all is more about finding than returning macthing elements IMO).
But I have to recognize find_all is very explicit in the name.
