### PR TITLE
Recommend against rescuing Exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ in *Ruby* now, not in *Python*.
 
 * Don't suppress exceptions.
 * Don't use exceptions for flow of control.
+* Avoid rescuing the Exception class
 
 ## Misc
 


### PR DESCRIPTION
I see this one quite frequently, people write exception handlers that are a little too broad. You generally want to avoid rescuing the top level Exception class as you will trap exceptions like SyntaxError which you really want to see as early as possible.

The Ruby exception hierarchy is explained here:
http://www.skorks.com/2009/09/ruby-exceptions-and-exception-handling/
