### PR TITLE
Convert quotes to Markdown blockquote syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Abstract
 
-    Style is what separates the good from the great.
-    --Bozhidar Batsov
+> Style is what separates the good from the great. <br/>
+> -- Bozhidar Batsov
 
 One thing has always bothered me as Ruby developer - Python devs have
 a great programming style reference (PEP-8) and we never got an
@@ -86,10 +86,10 @@ wkhtmltopdf can be installed in one of two methods
 
 ## Formatting
 
-    ... nearly everybody is convinced that every style but their own is
-    ugly and unreadable. Leave out the "but their own" and they're
-    probably right...
-    --Jerry Coffin (on indentation)
+> Nearly everybody is convinced that every style but their own is
+> ugly and unreadable. Leave out the "but their own" and they're
+> probably right... <br/>
+> -- Jerry Coffin (on indentation)
 
 * Use UTF-8 as the source file encoding.
 * Use two-space indent, no tabs. Tabs are represented by a different
@@ -512,11 +512,11 @@ wkhtmltopdf can be installed in one of two methods
 
 ## Comments
 
-    Good code is its own best documentation. As you're about to add a
-    comment, ask yourself, ‘How can I improve the code so that this
-    comment isn't needed?’ Improve the code and then document it to make
-    it even clearer.
-    --Steve McConnell
+> Good code is its own best documentation. As you're about to add a
+> comment, ask yourself, "How can I improve the code so that this
+> comment isn't needed?" Improve the code and then document it to make
+> it even clearer. <br/>
+> -- Steve McConnell
 
 * Write self-documenting code and ignore the rest of this section. Seriously!
 * Comments longer than a word are capitalized and use punctuation. Use [one


### PR DESCRIPTION
I've converted the quotes to the Markdown block quote syntax.

Unfortunately (from [Gruber's guide](http://daringfireball.net/projects/markdown/syntax#p)): 

> When you do want to insert a `<br />` break tag using Markdown, you end a line with two or more spaces, then type return...Yes, this takes a tad more effort to create a `<br />`, but a simplistic "every line break is a `<br />`" rule wouldn’t work for Markdown. 

Two spaces at the end of the line? _FFFFFFFUUUUUUUUUUUU!_ My editor strips them out on save, anyway.

So we have to add a `<br />` tag manually, which, unfortunately, takes away from the readability of the plain text document. But I think they look a lot better after processing.

``` Markdown
     Before, we had quotes as code blocks.
     -- Phillip Ridlen

> Now, we have quotes as block quotes. <br />
> -- Phillip Ridlen
```

Rendered:

```
 Before, we had quotes as code blocks.
 -- Phillip Ridlen
```

> Now, we have quotes as block quotes.
> -- Phillip Ridlen

Feel free to merge this request or not :)
