### PR TITLE
Avoid page break in code blocks

### DIFF
--- a/stylesheets/default.css
+++ b/stylesheets/default.css
@@ -3,6 +3,7 @@ pre {
   border: solid 1px #CCC;
   padding: 5px 10px;
   font-family: 'Menlo', 'Courier New', 'Terminal', monospace;
+  page-break-inside: avoid;  
 }
 .hll { background-color: #ffffcc }
 .c { color: #408080; font-style: italic } /* Comment */


### PR DESCRIPTION
When I create the pdf I see already on the first page a code block with a page break going through it.
This should be avoided in my opinion.
## Alternative

It could be also considered to add a new css rule like 

``` css
body > ul > li {
  page-break-inside: avoid;
}
```

With this all list items consisting of a rule and a code example would not be split up on a page break.
