### PR TITLE
Empty lines before return values?

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,15 +160,16 @@ wkhtmltopdf can be installed in one of two methods
            end
     ```
 
-* Use an empty line before the return value of a method (unless it
-  only has one line), and an empty line between `def`s.
+* Use empty lines between `def`s and to break up a method into logical
+  paragraphs.
 
     ```Ruby
     def some_method
-      do_something
-      do_something_else
+      data = initialize(options)
 
-      result
+      data.manipulate!
+
+      data.result
     end
 
     def some_method
@@ -178,7 +179,6 @@ wkhtmltopdf can be installed in one of two methods
 
 * Use RDoc and its conventions for API documentation.  Don't put an
   empty line between the comment block and the `def`.
-* Use empty lines to break up a method into logical paragraphs.
 * Keep lines fewer than 80 characters.
     * Emacs users might want to put this in their config
       (e.g. `~/.emacs.d/init.el`):


### PR DESCRIPTION
I did some searching but couldn't find any discussion of the rationale behind this rule. It appears to me that it was carried over from style guides from other languages like C or Java. When dealing with long functions that may or may not return values I can imagine it might be useful to use whitespace to accentuate returns. But this is ruby! We don't need [explicit returns](https://github.com/bbatsov/ruby-style-guide/issues/9) and "most methods will be shorter than 5 LOC". In my opinion, the extra blank lines are redundant and make it harder to scan the code for logical chunks. 

I didn't come up with a clever regex to check usage in the wild but I did browse through the code for "Programming Ruby 1.9" as well as Rails and Sinatra and no one appeared to be adding the extra lines. Longer methods were broken into paragraphs which sometimes left the return value lonely, but not necessarily. I propose dropping the specific rule in favor of the more generic practice of using empty lines to delineate logical groupings.
