### PR TITLE
Outdent public, protected, and private keywords.

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,8 +678,8 @@ You can generate a PDF or an HTML copy of this guide using
 in accordance with their intended usage. Don't go off leaving
 everything `public` (which is the default). After all we're coding
 in *Ruby* now, not in *Python*.
-* Indent the `public`, `protected`, and `private` methods as much the
-  method definitions they apply to. Leave one blank line above them.
+* Outdent the `public`, `protected`, and `private` keywords to be in line
+  with the class that they belong to. Leave one blank line above them.
 
     ```Ruby
     class SomeClass
@@ -687,7 +687,7 @@ in *Ruby* now, not in *Python*.
         # ...
       end
 
-      private
+    private
       def private_method
         # ...
       end


### PR DESCRIPTION
This has been discussed previously in #31, but I much disagree with the
stance that was decided on. I want to open this up again for discussion.

The problem with having private in line with the method definitions is
that it goes unnoticed. There's no clear distinction between public and
private methods. It may not be so obvious here, but it's a lot more
important when your classes are hundreds of lines long.

```
class class Foo
  def bar
  end

  private
  def baz
  end
end
```

Outdent style, on the other hand, is quite visible and easy to read.
It's not semantically correct, but it's very similar to other similar
constructs that make sections of code. While `private` is technically a
method call, it acts to section off code, just like if/else and
begin/rescue. @burke is correct in #31 that it does not open a new
scope, but that hardly matters in the context of a class definition.
Similarly with a begin/rescue block, code in the rescue block can still
reference variables created in the begin section.

```
if
  foo
else
  bar
end

begin
  foo
rescue
  bar
end

class Foo
  def bar
  end

private
  def baz
  end
end
```

Finally, although no project's style stands as law, the Rails source has
certainly been the most influential in the Ruby community for setting
standards for code style. Much of their new code now uses the style I'm
suggesting.

For reference, this article talks about the pros and cons of each style.
http://fabiokung.com/2010/04/05/ruby-indentation-for-access-modifiers-and-their-sections/
