### PR TITLE
Syntax fix in 'omit parantheses' example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ You can generate a PDF or an HTML copy of this guide using
 
     ```Ruby
     class Person
-      attr_reader name, age
+      attr_reader :name, :age
 
       # omitted
     end


### PR DESCRIPTION
Syntax fix - should pass symbols to attr_ methods.
