### PR TITLE
Correct some erreoneous information about ruby execption handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,22 +857,35 @@ in *Ruby* now, not in *Python*.
       n / d
     ```
   
-* Avoid rescuing the `Exception` class.
+* Avoid rescuing the `Exception` class.  This will trap signals and calls to
+  `exit`, requiring you to `kill -9` the process.
 
     ```Ruby
-    # bad 
+    # bad
     begin
-      # an exception occurs here
-    rescue
+      # calls to exit and kill signals will be caught (except kill -9)
+      exit
+    rescue Exception
+      puts "you didn't really want to exit, right?"
       # exception handling
     end
 
-    # still bad
+    # good
     begin
-      # an exception occurs here
-    rescue Exception
+      # a blind rescue rescues from StandardError, not Exception as many
+      # programmers assume.
+    rescue => e
       # exception handling
     end
+
+    # also good
+    begin
+      # an exception occurs here
+
+    rescue StandardError => e
+      # exception handling
+    end
+
     ```
 
 * Put more specific exceptions higher up the rescue chain, otherwise


### PR DESCRIPTION
```
begin; rescue Exception; end
```

is not the same as

```
begin: rescue; end # this rescues from StandardError, not Exception
```

This former is a bad practice which results in processes that don't
respond to `kill` and other signals.  It's rarely what's intended.

Try this one for fun:

```
begin
  # calls to exit and kill signals will be caught (except kill -9)
  exit
rescue Exception
  puts "you didn't really want to exit, right?"
  # exception handling
end 
```
