### PR TITLE
Spaces around string interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1094,8 +1094,8 @@ syntax.
     email_with_name = "#{ user.name } <#{ user.email }>"
     ```
 
-* Prefer padding string interpolation code with space. It more clearly sets the
-  code apart from the string.
+* Consider padding string interpolation code with spaces. It more clearly sets
+  the code apart from the string.
 
     ```Ruby
     "#{ user.last_name }, #{ user.first_name }"


### PR DESCRIPTION
Please see #66.

A couple of things about this change-set:
1. Sorry about the trailing-whitespace noise, but it seemed appropriate considering not having trailing whitespace is part of the style-guide.
2. The first commit is just changing the examples of string interpolation. If the goal isn't to require this, then maybe just showing by example is enough...
3. The second commit has an entry explaining the suggestion. As per the discussion at #66, the idea here is to suggest this, and not require it. Now it starts with "Prefer", but I'm definitely open to softer wording. `Suggest padding string interpolation code with space` didn't make sense to me.
