### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -997,7 +997,7 @@ in *Ruby* now, not in *Python*.
     end
     ```
 
-* Never return form an `ensure` block. If you explicitly return from a
+* Never return from an `ensure` block. If you explicitly return from a
   method inside an `ensure` block, the return will take precedence over
   any exception being raised, and the method will return as if no
   exception had been raised at all. In effect, the exception will be


### PR DESCRIPTION
Simple problem, simple fix. The word "from" was mistyped as "form".
