### PR TITLE
Suggest Removing "Prefer single-quoted string" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -861,17 +861,6 @@ introducing new exception classes.
     "#{ user.last_name }, #{ user.first_name }"
     ```
 
-* Prefer single-quoted strings when you don't need string interpolation or
-  special symbols such as `\t`, `\n`, `'`, etc.
-
-    ```Ruby
-    # bad
-    name = "Bozhidar"
-
-    # good
-    name = 'Bozhidar'
-    ```
-
 * `String#<<` performs better by mutating the string in place.  `String#+`, avoids mutation (which is good
   in a functional way) but therefore runs slower since it creates a new string object.
 


### PR DESCRIPTION
While this may make the interpreter do a little less work, using single-quotes as the default can make the job of refactoring more difficult, and could make code with a lot of strings (like should blocks in tests) inconsistent. I suggest either leaving it up to the developer's judgement whether to use single- or double-quotes, OR, if we do want to have a consistent standard for our codebase, using double quotes as the default.
