### PR TITLE
Remove preference for spaces in interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1298,13 +1298,6 @@ strings.
     email_with_name = "#{user.name} <#{user.email}>"
     ```
 
-* Consider padding string interpolation code with space. It more clearly sets the
-  code apart from the string.
-
-    ```Ruby
-    "#{ user.last_name }, #{ user.first_name }"
-    ```
-
 * Prefer single-quoted strings when you don't need string interpolation or
   special symbols such as `\t`, `\n`, `'`, etc.
 


### PR DESCRIPTION
I don’t think it’s helpful and having guidelines like ‘consider’ is usually not a good idea—we either pad or not. I’m for not padding.
