### PR TITLE
Extra tick in 'Perl-style special variables' line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,7 +612,7 @@ would happen if the current value happened to be `false`.)
     enabled = true if enabled.nil?
     ```
 
-* Avoid using Perl-style special variables (like `$0-9`, `$``,
+* Avoid using Perl-style special variables (like `$0-9`, `$`,
   etc. ). They are quite cryptic and their use in anything but
   one-liner scripts is discouraged.
 


### PR DESCRIPTION
The formatted inline code block had an extra ` hanging off the end of it.
