### PR TITLE
Fix to_s example to be consistent on interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -893,7 +893,7 @@ at all.
       end
 
       def to_s
-        "#@first_name #@last_name"
+        "#{@first_name} #{@last_name}"
       end
     end
     ```


### PR DESCRIPTION
The `to_s` example still uses the old advice on instance variable interpolation that was changed in #142.
