### PR TITLE
Issue #156 - Add a small RSpec "no parenthesis" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,8 @@ Translations of the guide are available in the following languages:
 
     x = Math.sin(y)
     array.delete(e)
+
+    bowling.score.should == 0
     ```
 
 * Prefer `{...}` over `do...end` for single-line blocks.  Avoid using


### PR DESCRIPTION
The paragraph lists Situations. They're about when you should omit-parenthesis

It goes on to some Examples for each:
-attr_reader
-puts
-methods with no parameters

(There are more Examples I haven't listed; the ones for _include_-parenthesis Situations)

...This commit just adds one more Example. It's for a Situation that was mentioned in the paragraph but didn't have any Example: RSpec
