### PR TITLE
avoid global variables by using module instance variables instead of class instance variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1824,14 +1824,14 @@ strings.
 * Avoid parameter lists longer than three or four parameters.
 * If you really need "global" methods, add them to Kernel
   and make them private.
-* Use class instance variables instead of global variables.
+* Use module instance variables instead of global variables.
 
     ```Ruby
     # bad
     $foo_bar = 1
 
-    # good
-    class Foo
+    #good
+    module Foo
       class << self
         attr_accessor :bar
       end


### PR DESCRIPTION
The style guide recommends to use modules instead of classes, if it is not required to instantiate the object:

```
Classes should be used only when it makes sense to create instances out of them.
```

The last example, which demonstrates how to avoid global variables by encapsulating them in an object, uses a class, although it never gets instantiated:

```
Use class instance variables instead of global variables.

...

#good
class Foo
  class << self
    attr_accessor :bar
  end
end

Foo.bar = 1
```

To be more consistent with the previous suggestion i would like to ask to use a module in the example instead of a class.
