### PR TITLE
Avoid hashes as optional parameters exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -1776,7 +1776,7 @@ strings.
 ## Misc
 
 * Write `ruby -w` safe code.
-* Avoid hashes as optional parameters. Does the method do too much?
+* Avoid hashes as optional parameters. Does the method do too much? (Object initializers are exceptions for this rule).
 * Avoid methods longer than 10 LOC (lines of code). Ideally, most methods will be shorter than
   5 LOC. Empty lines do not contribute to the relevant LOC.
 * Avoid parameter lists longer than three or four parameters.


### PR DESCRIPTION
except for object initializers.
