### PR TITLE
Always a controversial topic, but I'm against

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,6 @@ Translations of the guide are available in the following languages:
 
 * Use RDoc and its conventions for API documentation.  Don't put an
   empty line between the comment block and the `def`.
-* Limit lines to 80 characters.
 * Avoid trailing whitespace.
 
 ## Syntax


### PR DESCRIPTION
Most of the arguments seems to stem from being
able to work with code conveniently in split
windows on small windows.

I find that a hard limit on characters leads to
less readable code. More so in verboser languages
like Java, but also for Ruby.
