### PR TITLE
Use a space after # in a comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1034,7 +1034,8 @@ setting the warn level to 0 via `-W0`).
 
 * Write self-documenting code and ignore the rest of this section. Seriously!
 * Write comments in English.
-* Use one space between the `#` character and the text of the comment.
+* Use one space between the leading `#` character of the comment and the text
+  of the comment.
 * Comments longer than a word are capitalized and use punctuation. Use [one
   space](http://en.wikipedia.org/wiki/Sentence_spacing) after periods.
 * Avoid superfluous comments.


### PR DESCRIPTION
All of the comments in the style guide follow this format.  See also [PEP-8](http://www.python.org/dev/peps/pep-0008/#inline-comments), [this Stack Overflow question](http://stackoverflow.com/q/1467058/126042), etc.
