### PR TITLE
Clarified usage of `fetch` with two arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1692,7 +1692,7 @@ this rule only to arrays with two or more elements.
     # good - fetch raises a KeyError making the problem obvious
     heroes.fetch(:supermann)
     ```
-* Use `fetch` with second argument to set a default value
+* Use `fetch` with second argument to use a default value
 
    ```Ruby
    batman = { name: 'Bruce Wayne', is_evil: false }


### PR DESCRIPTION
The description of `fetch` indicated that passing in a second argument would allow you to "set" a default argument. This surprised me - does this mean `fetch` will set the value of that key in the hash? I had to go into irb to check, and it does not. =)

I changed the wording from "set" to "use" to make it clearer that you're not mutating the hash when you return a default value..
