### PR TITLE
Add more examples for use unless case

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,11 +543,6 @@ modules). Never use `::` for method invocation.
     # good
     do_something unless some_condition
 
-    # good
-    unless some_condition
-      # body omitted
-    end
-
     # another good option
     some_condition or do_something
     ```


### PR DESCRIPTION
add another case for use unless. I saw in many places something like: 'if not current_user'. I think it's a bad way to do that.
