### PR TITLE
Single line class definition utilize Class.new

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,11 @@ Translations of the guide are available in the following languages:
     class FooError < StandardError
     end
 
-    # good
+    # okish
     class FooError < StandardError; end
+    
+    # good
+    FooError = Class.new(StandardError)
     ```
 
 * Avoid single-line methods. Although they are somewhat popular in the


### PR DESCRIPTION
The Class.new version is a cleaner syntax and removes the unwanted `;` that is included in the default class syntax.
