### PR TITLE
include '.' on first line of multiline chained method invocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,16 +309,16 @@ Translations of the guide are available in the following languages:
              - 2
     ```
 
-* When continuing a chained method invocation on another line keep the `.` on the second line.
+* When continuing a chained method invocation on another line, include the `.` on the first line to indicate that the expression continues.
 
     ```Ruby
-    # bad - need to consult first line to understand second line
-    one.two.three.
-      four
-
-    # good - it's immediately clear what's going on the second line
+    # bad - need to read ahead to the second line to know that the chain continues
     one.two.three
       .four
+
+    # good - it's immediately clear that the expression continues beyond the first line
+    one.two.three.
+      four
     ```
 
 * Align the parameters of a method call if they span more than one line.


### PR DESCRIPTION
This changes where the `.` lives from the second line to the first line in the expression. Having no `.` at the end of the first line makes that line appear to be complete, but you must read ahead to the next line in order to see that the expression continues.

This closes issue #169
