### PR TITLE
Avoid side effects in predicate methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1032,6 +1032,16 @@ setting the warn level to 0 via `-W0`).
 * The names of predicate methods (methods that return a boolean value)
   should end in a question mark.
   (i.e. `Array#empty?`).
+* Predicate methods should not have side-effects
+
+```Ruby
+# bad
+def homeless?
+  puts "Side effect"  
+  homes.empty?
+end
+```
+
 * The names of potentially *dangerous* methods (i.e. methods that
   modify `self` or the arguments, `exit!` (doesn't run the finalizers
   like `exit` does), etc.) should end with an exclamation mark if


### PR DESCRIPTION
Side effects in predicate methods are typically unexpected. I have seen this kind of use in Rails projects for custom validation methods on a model, where a predicate method both returns a boolean and adds an error on the model object.
