### PR TITLE
Minor fix to comment in local variable shadowing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,8 +800,8 @@ modules). Never use `::` for method invocation.
 
       # ok
       def initialize(options)
+        # @options and self.options are equivalent here
         self.options = options
-        # both options and self.options are equivalent here
       end
 
       # bad


### PR DESCRIPTION
I believe it's "@options" that's meant here rather than "options"; the latter refers to the method parameter and is not equivalent to self.options.

Also moved comment above the referenced line and omitted the unnecessary word "both".
