### PR TITLE
Typo in Percent Literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -2117,7 +2117,7 @@ this rule only to arrays with two or more elements.
 
     # good
     %w(one tho three)
-    %q{"Test's king!", John said.}
+    %q("Test's king!", John said.)
     ```
 
 ## Metaprogramming


### PR DESCRIPTION
It should be a typo in suggestion to prefer `()` brackets with percent literals
