### PR TITLE
added fetch with blocks condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1856,7 +1856,7 @@ this rule only to arrays with two or more elements.
     # good - fetch raises a KeyError making the problem obvious
     heroes.fetch(:supermann)
     ```
-* Use `fetch` with second argument to use a default value
+* Use `fetch` with second argument to use a default value.
 
    ```Ruby
    batman = { name: 'Bruce Wayne', is_evil: false }
@@ -1868,14 +1868,14 @@ this rule only to arrays with two or more elements.
    batman.fetch(:is_evil, true) # => false
    ```
 
-* Prefer the use of the block instead of the default value in `fetch`
+* Prefer the use of the block instead of the default value in `fetch`.
 
    ```Ruby
-   batman = {name: 'Bruce Wayne'}
+   batman = { name: 'Bruce Wayne' }
    
    # bad - if we use the default value, we eager evaluate it
    # so it can slow the program down if done multiple times
-   batman.fetch(:powers, get_batman_powers) # get_batman_powers has an expensive call
+   batman.fetch(:powers, get_batman_powers) # get_batman_powers is an expensive call
 
    # good - blocks are lazy evaluated, so only triggered in case of KeyError exception
 


### PR DESCRIPTION
##### blocks are lazy evaluated while the default value (provided as second argument) is eagerly evaluated.

The concern is not when you don't hit the key (in this case the default value will be called anyway, regardless if you are in second argument case or block case

The concern is _when the key is hit_, which probably is like 99% of the time.
