### PR TITLE
Prefer Time.now over Time.new

### DIFF
--- a/README.md
+++ b/README.md
@@ -2226,6 +2226,7 @@ this rule only to arrays with two or more elements.
 * Avoid `alias` when `alias_method` will do.
 * Use `OptionParser` for parsing complex command line options and
 `ruby -s` for trivial command line options.
+* Prefer `Time.now` over `Time.new` when retrieving the current system time.
 * Code in a functional way, avoiding mutation when that makes sense.
 * Do not mutate arguments unless that is the purpose of the method.
 * Avoid more than three levels of block nesting.


### PR DESCRIPTION
The documentation says now is an alias for new. I believe Time.now more
clearly conveys that it uses the current time, whereas Time.new does not
convey the current time vs. an arbitrary, empty time object.

GitHub search indicates that Time.now is far more popular:
- Time.now has [376,997 code results](https://github.com/search?l=ruby&q=time.now&source=c&type=Code)
- Time.new has [18,858 code results](https://github.com/search?l=ruby&q=time.new&source=c&type=Code)

The ratio of now:new is approximately 20:1.
