### PR TITLE
updated style guide with instructions for calling constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,8 @@ as easy to spot as regular comments.
 ## Syntax
 
 * Use `::` only to reference constants(this includes classes and
-modules). Never use `::` for method invocation.
+modules) and constructors (like `Array()` or `Nokogiri::HTML()`).
+Never use `::` for regular method invocation.
 
     ```Ruby
     # bad
@@ -405,6 +406,7 @@ modules). Never use `::` for method invocation.
     SomeClass.some_method
     some_object.some_method
     SomeModule::SomeClass::SOME_CONST
+    SomeModule::SomeClass()
     ```
 
 * Use `def` with parentheses when there are arguments. Omit the


### PR DESCRIPTION
Added Nokogiri::HTML since it's an understandable example, normally I wouldn't want to reference to gems, but the regular ruby constructors aren't namespaced, so it doesn't apply there.
