### PR TITLE
Allow lambda keyword for single-line blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,15 +901,11 @@ would happen if the current value happened to be `false`.)
 * Always run the Ruby interpreter with the `-w` option so it will warn
 you if you forget either of the rules above!
 
-* Use the new lambda literal syntax for single line body blocks. Use the
-  `lambda` method for multi-line blocks.
+* Use `lambda` or the new lambda literal syntax (`->`) for single line body blocks.
+Use the `lambda` method for multi-line blocks.
 
     ```Ruby
     # bad
-    l = lambda { |a, b| a + b }
-    l.call(1, 2)
-
-    # correct, but looks extremely awkward
     l = ->(a, b) do
       tmp = a * 7
       tmp * b / 50
@@ -917,6 +913,9 @@ you if you forget either of the rules above!
 
     # good
     l = ->(a, b) { a + b }
+    l.call(1, 2)
+
+    l = lambda { |a, b| a + b }
     l.call(1, 2)
 
     l = lambda do |a, b|


### PR DESCRIPTION
J’aime bien les nouvelles additions de syntaxe avec Ruby 1.9, à l’exception de `->`.

Je propose donc qu’on puisse utiliser `->` _et_ `lambda` pour des blocs d’une ligne. Pour les blocs multi-lignes, on utilise toujours `lambda`, comme c’était le cas avec le style guide actuel.
