### PR TITLE
Remove misplaced "and"

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,8 +322,8 @@ Translations of the guide are available in the following languages:
       end
     ```
 
-* Use empty lines between `def`s and to break up a method into logical
-  paragraphs.
+* Use empty lines between method definitions and also to break up a method into logical
+  paragraphs internally.
 
     ```Ruby
     def some_method


### PR DESCRIPTION
In the sentence that discusses creating "logical paragraphs" for
methods, there is a misplaced "and" that makes the sentence difficult to
understand. It does not seem to have any reason to exist.

This commit removes the rogue "and" from the sentence.
