### PR TITLE
Made naming directions of predicate methods a bit more specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -1297,7 +1297,8 @@ setting the warn level to 0 via `-W0`).
 
 * The names of predicate methods (methods that return a boolean value)
   should end in a question mark.
-  (i.e. `Array#empty?`).
+  (i.e. `Array#empty?`). Methods that don't return a boolean, shouldn't
+  end in a question mark.
 * The names of potentially *dangerous* methods (i.e. methods that
   modify `self` or the arguments, `exit!` (doesn't run the finalizers
   like `exit` does), etc.) should end with an exclamation mark if


### PR DESCRIPTION
I'd like to kindly disagree with the naming choices in: http://batsov.com/articles/2013/09/24/lambdas-slash-procs-in-case-expressions/

I think adding a ? will result in an expectation that the method returns a boolean. However, it returns a lambda, which will be truthy (I guess), which might lead to obscure bugs, or at least suprised faces.
