### PR TITLE
Use `size` over `length` in example code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Translations of the guide are available in the following languages:
 
     ```Ruby
     some(arg).other
-    [1, 2, 3].length
+    [1, 2, 3].size
     ```
 
 * No space after `!`.


### PR DESCRIPTION
The guide suggests preferring the use of `size` over `length`, but one of the code snippets doesn't follow this rule.

[fixes #250]
