### PR TITLE
Add rules about trailing commas.

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,24 @@ Translations of the guide are available in the following languages:
     end
     ```
 
+* Avoid comma after the last parameter in a method definition or call,
+  especially when the parameters are not on separate lines.
+
+    ```Ruby
+    # bad - easier to move/add/remove parameters, but still not preferred
+    def some_method(
+                     size,
+                     count,
+                     color,
+                   )
+
+    # bad
+    def some_method(size, count, color, )
+
+    # good
+    def some_method(size, count, color)
+    ```
+
 * Use spaces around the `=` operator when assigning default values to method parameters:
 
     ```Ruby
@@ -2102,6 +2120,24 @@ this rule only to arrays with two or more elements.
 
     # good
     STATES = %i(draft open closed)
+    ```
+
+* Avoid comma after the last item of an `Array` or `Hash` literal, especially
+  when the items are not on separate lines.
+
+    ```Ruby
+    # bad - easier to move/add/remove items, but still not preferred
+    VALUES = [
+               1001,
+               2020,
+               3333,
+             ]
+
+    # bad
+    VALUES = [1001, 2020, 3333, ]
+
+    # good
+    VALUES = [1001, 2020, 3333]
     ```
 
 * Avoid the creation of huge gaps in arrays.


### PR DESCRIPTION
Can occur in literals and method definitions/calls. These rules were discussed in https://github.com/bbatsov/rubocop/issues/713
