### PR TITLE
fix typo of a "salary" word in russian:

### DIFF
--- a/README.md
+++ b/README.md
@@ -1338,10 +1338,10 @@ setting the warn level to 0 via `-W0`).
 
     ```Ruby
     # bad - identifier using non-ascii characters
-    заплата = 1_000
+    зарплата = 1_000
 
     # bad - identifier is a Bulgarian word, written with Latin letters (instead of Cyrillic)
-    zaplata = 1_000
+    zarplata = 1_000
 
     # good
     salary = 1_000


### PR DESCRIPTION
ru-en Translation:
http://translate.google.com/#ru/en/%D0%B7%D0%B0%D1%80%D0%BF%D0%BB%D0%B0%D1%82%D0%B0
