### PR TITLE
Fix link for Wikipedia SOLID article

### DIFF
--- a/README.md
+++ b/README.md
@@ -1795,7 +1795,7 @@ at all.
 * When designing class hierarchies make sure that they conform to the
   [Liskov Substitution Principle](http://en.wikipedia.org/wiki/Liskov_substitution_principle).
 * Try to make your classes as
-  [SOLID](http://en.wikipedia.org/wiki/SOLID_(object-oriented_design\))
+  [SOLID](http://en.wikipedia.org/wiki/SOLID_\(object-oriented_design\))
   as possible.
 * Always supply a proper `to_s` method for classes that represent
   domain objects.


### PR DESCRIPTION
The link to the SOLID Wikipedia article is not rendered correctly.

[SOLID](http://en.wikipedia.org/wiki/SOLID_(object-oriented_design\))
vs.
[SOLID](http://en.wikipedia.org/wiki/SOLID_%28object-oriented_design%29)
