### PR TITLE
remove the constraint for not using double bang operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,27 +703,6 @@ Never use `::` for regular method invocation.
     x = !something
     ```
 
-* Avoid the use of `!!`.
-
-    ```Ruby
-    # bad
-    x = 'test'
-    # obscure nil check
-    if !!x
-      # body omitted
-    end
-
-    x = false
-    # double negation is useless on booleans
-    !!x # => false
-
-    # good
-    x = 'test'
-    unless x.nil?
-      # body omitted
-    end
-    ```
-
 * The `and` and `or` keywords are banned. It's just not worth
   it. Always use `&&` and `||` instead.
 


### PR DESCRIPTION
The double bang `!!` is a standard ruby operator that is no more obscure than other literals such as `%w`, or `!`. Any misunderstanding, or misinterpretation is more of an issue of not understanding the ruby library, than it is the operator being obscure.
