### PR TITLE
Avoid if/unless at the end of a non-trivial block

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,6 +771,23 @@ Translations of the guide are available in the following languages:
   some_condition && do_something
   ```
 
+* Avoid modifier `if/unless` usage at the end of a
+  non-trivial multi-line block.
+
+  ```Ruby
+  # bad
+  10.times do
+    # multi-line body omitted
+  end if some_condition
+  
+  # good
+  if some_condition
+    10.times do
+      # multi-line body omitted
+    end
+  end
+  ```
+
 * Favor `unless` over `if` for negative conditions (or control
   flow `||`).
 


### PR DESCRIPTION
Using an `if` or `unless` modifier at the end of a non-trivial multi-line block requires reading all the way to the end of the block before the reader becomes aware that the block is guarded by a condition.

Additionally, in the case where the code is being viewed as part of a patch, the condition at the end of the block may not even be visible in the diff context; this can make code reviews harder.
