### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2903,7 +2903,7 @@ Translations of the guide are available in the following languages:
   # bad
   $foo_bar = 1
 
-  #good
+  # good
   module Foo
     class << self
       attr_accessor :bar


### PR DESCRIPTION
As described in this README.md,

> Use one space between the leading `#` character of the comment and the text of the comment.

:-)
