### PR TITLE
Fix while/until typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -890,7 +890,7 @@ Translations of the guide are available in the following languages:
       do_something
     end
 
-    while false
+    until false
       do_something
     end
 


### PR DESCRIPTION
In the infinite loop session, the guide used "while false" instead of "until false".
