### PR TITLE
Multiple assignments per expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -1142,7 +1142,7 @@ Translations of the guide are available in the following languages:
   @current_opts = opts
 
   # good - shorthand assignment
-  @current_locks, @current_opts = locs, opts
+  @current_locks, @current_opts = locks, opts
 
   # bad - subtle bug, equivalent to @current_locks = [locks, opts]
   @current_locks = locks, @current_opts = opts


### PR DESCRIPTION
@lolmaus tracked this down in https://github.com/middleman/middleman/issues/501#issuecomment-44087354, and I thought it would be a good addition to the style guide / rubocop.

Perhaps I over generalized, but I would be in favor of any recommendation that catches this code:

``` ruby
@current_locks = locks, @current_opts = opts
```
