### PR TITLE
Update a couple inconsistent commented outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,13 +596,13 @@ Translations of the guide are available in the following languages:
   end
 
   # note that elem is accessible outside of the for loop
-  elem #=> 3
+  elem # => 3
 
   # good
   arr.each { |elem| puts elem }
 
   # elem is not accessible outside each's block
-  elem #=> NameError: undefined local variable or method `elem'
+  elem # => NameError: undefined local variable or method `elem'
   ```
 
 * Never use `then` for multi-line `if/unless`.
@@ -2665,7 +2665,7 @@ Translations of the guide are available in the following languages:
     |  other_method
     |end
   END
-  #=> "def test\n  some_method\n  other_method\nend\n"
+  # => "def test\n  some_method\n  other_method\nend\n"
   ```
 
 ## Regular Expressions


### PR DESCRIPTION
Updates `#=>` to `# =>` in a couple places. This is intended to be a small change which makes examples in this tutorial more consistent.

Just in case someone asks why should we prefer `# =>`:
- used in TRPL and pickaxe books
- this guide itself recommends using one space after the leading `#`
- majority of other examples already use `# =>`
