### PR TITLE
Add anchors to bullets

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,13 @@ Translations of the guide are available in the following languages:
 > probably right... <br/>
 > -- Jerry Coffin (on indentation)
 
-* Use `UTF-8` as the source file encoding.
-* Use two **spaces** per indentation level (aka soft tabs). No hard tabs.
+* <a name="utf-8"></a>
+  Use `UTF-8` as the source file encoding.
+<sup>[[link](#utf-8)]</sup>
+
+* <a name="spaces-indentation"></a>
+  Use two **spaces** per indentation level (aka soft tabs). No hard tabs.
+<sup>[[link](#spaces-indentation)]</sup>
 
   ```Ruby
   # bad - four spaces
@@ -114,8 +119,11 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Use Unix-style line endings. (*BSD/Solaris/Linux/OS X users are covered by default,
-  Windows users have to be extra careful.)
+* <a name="crlf"></a>
+  Use Unix-style line endings. (*BSD/Solaris/Linux/OS X users are covered by
+  default, Windows users have to be extra careful.)
+<sup>[[link](#crlf)]</sup>
+
   * If you're using Git you might want to add the following
     configuration setting to protect your project from Windows line
     endings creeping in:
@@ -124,8 +132,10 @@ Translations of the guide are available in the following languages:
     $ git config --global core.autocrlf true
     ```
 
-* Don't use `;` to separate statements and expressions. As a
-  corollary - use one expression per line.
+* <a name="no-semicolon"></a>
+  Don't use `;` to separate statements and expressions. As a corollary - use one
+  expression per line.
+<sup>[[link](#no-semicolon)]</sup>
 
   ```Ruby
   # bad
@@ -142,7 +152,9 @@ Translations of the guide are available in the following languages:
   puts 'foo', 'bar' # this applies to puts in particular
   ```
 
-* Prefer a single-line format for class definitions with no body.
+* <a name="single-line-classes"></a>
+  Prefer a single-line format for class definitions with no body.
+<sup>[[link](#single-line-classes)]</sup>
 
   ```Ruby
   # bad
@@ -156,10 +168,12 @@ Translations of the guide are available in the following languages:
   FooError = Class.new(StandardError)
   ```
 
-* Avoid single-line methods. Although they are somewhat popular in the
-  wild, there are a few peculiarities about their definition syntax
-  that make their use undesirable. At any rate - there should be no more
-  than one expression in a single-line method.
+* <a name="no-single-line-methods"></a>
+  Avoid single-line methods. Although they are somewhat popular in the wild,
+  there are a few peculiarities about their definition syntax that make their
+  use undesirable. At any rate - there should be no more than one expression in
+  a single-line method.
+<sup>[[link](#no-single-line-methods)]</sup>
 
   ```Ruby
   # bad
@@ -187,10 +201,11 @@ Translations of the guide are available in the following languages:
   def no_op; end
   ```
 
-* Use spaces around operators, after commas, colons and semicolons, around `{`
+* <a name="spaces-operators"></a>
+  Use spaces around operators, after commas, colons and semicolons, around `{`
   and before `}`. Whitespace might be (mostly) irrelevant to the Ruby
-  interpreter, but its proper use is the key to writing easily
-  readable code.
+  interpreter, but its proper use is the key to writing easily readable code.
+<sup>[[link](#spaces-operators)]</sup>
 
   ```Ruby
   sum = 1 + 2
@@ -242,14 +257,18 @@ Translations of the guide are available in the following languages:
   (arguably) a bit more readable. As with hashes - pick one style
   and apply it consistently.
 
-* No spaces after `(`, `[` or before `]`, `)`.
+* <a name="no-spaces-braces"></a>
+  No spaces after `(`, `[` or before `]`, `)`.
+<sup>[[link](#no-spaces-braces)]</sup>
 
   ```Ruby
   some(arg).other
   [1, 2, 3].size
   ```
 
-* No space after `!`.
+* <a name="no-space-bang"></a>
+  No space after `!`.
+<sup>[[link](#no-space-bang)]</sup>
 
   ```Ruby
   # bad
@@ -259,9 +278,11 @@ Translations of the guide are available in the following languages:
   !something
   ```
 
-* Indent `when` as deep as `case`. I know that many would disagree
+* <a name="indent-when-to-case"></a>
+  Indent `when` as deep as `case`. I know that many would disagree
   with this one, but it's the style established in both "The Ruby
   Programming Language" and "Programming Ruby".
+<sup>[[link](#indent-when-to-case)]</sup>
 
   ```Ruby
   # bad
@@ -289,8 +310,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* When assigning the result of a conditional expression to a variable, preserve
-  the usual alignment of its branches.
+* <a name="indent-conditional-assignment"></a>
+  When assigning the result of a conditional expression to a variable,
+  preserve the usual alignment of its branches.
+<sup>[[link](#indent-conditional-assignment)]</sup>
 
   ```Ruby
   # bad - pretty convoluted
@@ -344,8 +367,10 @@ Translations of the guide are available in the following languages:
     end
   ```
 
-* Use empty lines between method definitions and also to break up a method
+* <a name="empty-lines-between-methods"></a>
+  Use empty lines between method definitions and also to break up a method
   into logical paragraphs internally.
+<sup>[[link](#empty-lines-between-methods)]</sup>
 
   ```Ruby
   def some_method
@@ -361,8 +386,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Avoid comma after the last parameter in a method call, especially when the
+* <a name="no-trailing-params-comma"></a>
+  Avoid comma after the last parameter in a method call, especially when the
   parameters are not on separate lines.
+<sup>[[link](#no-trailing-params-comma)]</sup>
 
   ```Ruby
   # bad - easier to move/add/remove parameters, but still not preferred
@@ -379,7 +406,10 @@ Translations of the guide are available in the following languages:
   some_method(size, count, color)
   ```
 
-* Use spaces around the `=` operator when assigning default values to method parameters:
+* <a name="spaces-around-equals"></a>
+  Use spaces around the `=` operator when assigning default values to method
+  parameters:
+<sup>[[link](#spaces-around-equals)]</sup>
 
   ```Ruby
   # bad
@@ -396,8 +426,10 @@ Translations of the guide are available in the following languages:
   While several Ruby books suggest the first style, the second is much more prominent
   in practice (and arguably a bit more readable).
 
-* Avoid line continuation `\` where not required. In practice, avoid using
+* <a name="no-trailing-backslash"></a>
+  Avoid line continuation `\` where not required. In practice, avoid using
   line continuations for anything but string concatenation.
+<sup>[[link](#no-trailing-backslash)]</sup>
 
   ```Ruby
   # bad
@@ -412,9 +444,11 @@ Translations of the guide are available in the following languages:
                 ' and second part of the long string'
   ```
 
-* Adopt a consistent multi-line method chaining style. There are two
-  popular styles in the Ruby community, both of which are considered
-  good - leading `.` (Option A) and trailing `.` (Option B).
+* <a name="consistent-multi-line-chains"></a>
+    Adopt a consistent multi-line method chaining style. There are two
+    popular styles in the Ruby community, both of which are considered
+    good - leading `.` (Option A) and trailing `.` (Option B).
+<sup>[[link](#consistent-multi-line-chains)]</sup>
 
   * **(Option A)** When continuing a chained method invocation on
     another line keep the `.` on the second line.
@@ -446,10 +480,12 @@ Translations of the guide are available in the following languages:
   A discussion on the merits of both alternative styles can be found
   [here](https://github.com/bbatsov/ruby-style-guide/pull/176).
 
-* Align the parameters of a method call if they span more than one
-  line. When aligning parameters is not appropriate due to line-length
-  constraints, single indent for the lines after the first is also
-  acceptable.
+* <a name="no-double-indent"></a>
+    Align the parameters of a method call if they span more than one
+    line. When aligning parameters is not appropriate due to line-length
+    constraints, single indent for the lines after the first is also
+    acceptable.
+<sup>[[link](#no-double-indent)]</sup>
 
   ```Ruby
   # starting point (line is too long)
@@ -485,7 +521,9 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Align the elements of array literals spanning multiple lines.
+* <a name="align-multiline-arrays"></a>
+  Align the elements of array literals spanning multiple lines.
+<sup>[[link](#align-multiline-arrays)]</sup>
 
   ```Ruby
   # bad - single indent
@@ -504,7 +542,9 @@ Translations of the guide are available in the following languages:
      'Baked beans', 'Spam', 'Spam', 'Spam', 'Spam', 'Spam']
   ```
 
-* Add underscores to large numeric literals to improve their readability.
+* <a name="underscores-in-numerics"></a>
+  Add underscores to large numeric literals to improve their readability.
+<sup>[[link](#underscores-in-numerics)]</sup>
 
   ```Ruby
   # bad - how many 0s are there?
@@ -514,17 +554,27 @@ Translations of the guide are available in the following languages:
   num = 1_000_000
   ```
 
-* Use RDoc and its conventions for API documentation.  Don't put an
-  empty line between the comment block and the `def`.
+* <a name="rdoc-conventions"></a>
+    Use RDoc and its conventions for API documentation.  Don't put an
+    empty line between the comment block and the `def`.
+<sup>[[link](#rdoc-conventions)]</sup>
 
-* Limit lines to 80 characters.
+* <a name="80-character-limits"></a>
+  Limit lines to 80 characters.
+<sup>[[link](#80-character-limits)]</sup>
 
-* Avoid trailing whitespace.
+* <a name="no-trailing-whitespace"></a>
+  Avoid trailing whitespace.
+<sup>[[link](#no-trailing-whitespace)]</sup>
 
-* End each file with a newline.
+* <a name="newline-eof"></a>
+  End each file with a newline.
+<sup>[[link](#newline-eof)]</sup>
 
-* Don't use block comments. They cannot be preceded by whitespace and are not
-  as easy to spot as regular comments.
+* <a name="no-block-comments"></a>
+    Don't use block comments. They cannot be preceded by whitespace and are not
+    as easy to spot as regular comments.
+<sup>[[link](#no-block-comments)]</sup>
 
   ```Ruby
   # bad
@@ -540,9 +590,11 @@ Translations of the guide are available in the following languages:
 
 ## Syntax
 
-* Use `::` only to reference constants(this includes classes and
-  modules) and constructors (like `Array()` or `Nokogiri::HTML()`).
-  Never use `::` for regular method invocation.
+* <a name="double-colons"></a>
+    Use `::` only to reference constants(this includes classes and
+    modules) and constructors (like `Array()` or `Nokogiri::HTML()`).
+    Never use `::` for regular method invocation.
+<sup>[[link](#double-colons)]</sup>
 
   ```Ruby
   # bad
@@ -556,8 +608,10 @@ Translations of the guide are available in the following languages:
   SomeModule::SomeClass()
   ```
 
-* Use `def` with parentheses when there are arguments. Omit the
-  parentheses when the method doesn't accept any arguments.
+* <a name="method-parens"></a>
+    Use `def` with parentheses when there are arguments. Omit the
+    parentheses when the method doesn't accept any arguments.
+<sup>[[link](#method-parens)]</sup>
 
    ```Ruby
    # bad
@@ -581,11 +635,13 @@ Translations of the guide are available in the following languages:
    end
    ```
 
-* Never use `for`, unless you know exactly why. Most of the time iterators
-  should be used instead. `for` is implemented in terms of `each` (so
-  you're adding a level of indirection), but with a twist - `for`
-  doesn't introduce a new scope (unlike `each`) and variables defined
-  in its block will be visible outside it.
+* <a name="no-for-loops"></a>
+    Never use `for`, unless you know exactly why. Most of the time iterators
+    should be used instead. `for` is implemented in terms of `each` (so
+    you're adding a level of indirection), but with a twist - `for`
+    doesn't introduce a new scope (unlike `each`) and variables defined
+    in its block will be visible outside it.
+<sup>[[link](#no-for-loops)]</sup>
 
   ```Ruby
   arr = [1, 2, 3]
@@ -605,7 +661,9 @@ Translations of the guide are available in the following languages:
   elem # => NameError: undefined local variable or method `elem'
   ```
 
-* Never use `then` for multi-line `if/unless`.
+* <a name="no-then"></a>
+  Never use `then` for multi-line `if/unless`.
+<sup>[[link](#no-then)]</sup>
 
   ```Ruby
   # bad
@@ -619,7 +677,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Always put the condition on the same line as the `if`/`unless` in a multi-line conditional.
+* <a name="same-line-condition"></a>
+  Always put the condition on the same line as the `if`/`unless` in a
+  multi-line conditional.
+<sup>[[link](#same-line-condition)]</sup>
 
   ```Ruby
   # bad
@@ -636,8 +697,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Favor the ternary operator(`?:`) over `if/then/else/end` constructs.
+* <a name="ternary-operator"></a>
+  Favor the ternary operator(`?:`) over `if/then/else/end` constructs.
   It's more common and obviously more concise.
+<sup>[[link](#ternary-operator)]</sup>
 
   ```Ruby
   # bad
@@ -647,9 +710,11 @@ Translations of the guide are available in the following languages:
   result = some_condition ? something : something_else
   ```
 
-* Use one expression per branch in a ternary operator. This
+* <a name="no-nested-ternary"></a>
+  Use one expression per branch in a ternary operator. This
   also means that ternary operators must not be nested. Prefer
   `if/else` constructs in these cases.
+<sup>[[link](#no-nested-ternary)]</sup>
 
   ```Ruby
   # bad
@@ -663,8 +728,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Never use `if x: ...` - as of Ruby 1.9 it has been removed. Use
-  the ternary operator instead.
+* <a name="no-1.8-if-syntax"></a>
+  Never use `if x: ...` - as of Ruby 1.9 it has been removed. Use the ternary
+  operator instead.
+<sup>[[link](#no-1.8-if-syntax)]</sup>
 
   ```Ruby
   # bad
@@ -674,9 +741,14 @@ Translations of the guide are available in the following languages:
   result = some_condition ? something : something_else
   ```
 
-* Never use `if x; ...`. Use the ternary operator instead.
+* <a name="no-semicolon-ifs"></a>
+  Never use `if x; ...`. Use the ternary operator instead.
+<sup>[[link](#no-semicolon-ifs)]</sup>
 
-* Leverage the fact that `if` and `case` are expressions which return a result.
+* <a name="use-if-case-returns"></a>
+  Leverage the fact that `if` and `case` are expressions which return a
+  result.
+<sup>[[link](#use-if-case-returns)]</sup>
 
   ```Ruby
   # bad
@@ -695,12 +767,18 @@ Translations of the guide are available in the following languages:
     end
   ```
 
-* Use `when x then ...` for one-line cases. The alternative syntax
-  `when x: ...` has been removed as of Ruby 1.9.
+* <a name="one-line-cases"></a>
+  Use `when x then ...` for one-line cases. The alternative syntax `when x:
+  ...` has been removed as of Ruby 1.9.
+<sup>[[link](#one-line-cases)]</sup>
 
-* Never use `when x; ...`. See the previous rule.
+* <a name="no-when-semicolons"></a>
+  Never use `when x; ...`. See the previous rule.
+<sup>[[link](#no-when-semicolons)]</sup>
 
-* Use `!` instead of `not`.
+* <a name="bang-not-not"></a>
+  Use `!` instead of `not`.
+<sup>[[link](#bang-not-not)]</sup>
 
   ```Ruby
   # bad - braces are required because of op precedence
@@ -710,7 +788,9 @@ Translations of the guide are available in the following languages:
   x = !something
   ```
 
-* Avoid the use of `!!`.
+* <a name="no-bang-bang"></a>
+  Avoid the use of `!!`.
+<sup>[[link](#no-bang-bang)]</sup>
 
   ```Ruby
   # bad
@@ -731,8 +811,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* The `and` and `or` keywords are banned. It's just not worth
-  it. Always use `&&` and `||` instead.
+* <a name="no-and-or-or"></a>
+  The `and` and `or` keywords are banned. It's just not worth it. Always use
+  `&&` and `||` instead.
+<sup>[[link](#no-and-or-or)]</sup>
 
   ```Ruby
   # bad
@@ -754,10 +836,14 @@ Translations of the guide are available in the following languages:
   document.saved? || document.save!
   ```
 
-* Avoid multi-line `?:` (the ternary operator); use `if/unless` instead.
+* <a name="no-multiline-ternary"></a>
+  Avoid multi-line `?:` (the ternary operator); use `if/unless` instead.
+<sup>[[link](#no-multiline-ternary)]</sup>
 
-* Favor modifier `if/unless` usage when you have a single-line
-  body. Another good alternative is the usage of control flow `&&/||`.
+* <a name="if-as-a-modifier"></a>
+  Favor modifier `if/unless` usage when you have a single-line body. Another
+  good alternative is the usage of control flow `&&/||`.
+<sup>[[link](#if-as-a-modifier)]</sup>
 
   ```Ruby
   # bad
@@ -772,8 +858,10 @@ Translations of the guide are available in the following languages:
   some_condition && do_something
   ```
 
-* Avoid modifier `if/unless` usage at the end of a
-  non-trivial multi-line block.
+* <a name="no-multiline-if-modifiers"></a>
+  Avoid modifier `if/unless` usage at the end of a non-trivial multi-line
+  block.
+<sup>[[link](#no-multiline-if-modifiers)]</sup>
 
   ```Ruby
   # bad
@@ -789,8 +877,9 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Favor `unless` over `if` for negative conditions (or control
-  flow `||`).
+* <a name="unless-for-negatives"></a>
+  Favor `unless` over `if` for negative conditions (or control flow `||`).
+<sup>[[link](#unless-for-negatives)]</sup>
 
   ```Ruby
   # bad
@@ -806,7 +895,9 @@ Translations of the guide are available in the following languages:
   some_condition || do_something
   ```
 
-* Never use `unless` with `else`. Rewrite these with the positive case first.
+* <a name="no-else-with-unless"></a>
+  Never use `unless` with `else`. Rewrite these with the positive case first.
+<sup>[[link](#no-else-with-unless)]</sup>
 
   ```Ruby
   # bad
@@ -824,7 +915,9 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Don't use parentheses around the condition of an `if/unless/while/until`.
+* <a name="no-parens-if"></a>
+  Don't use parentheses around the condition of an `if/unless/while/until`.
+<sup>[[link](#no-parens-if)]</sup>
 
   ```Ruby
   # bad
@@ -838,7 +931,9 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Never use `while/until condition do` for multi-line `while/until`.
+* <a name="no-multiline-while-do"></a>
+  Never use `while/until condition do` for multi-line `while/until`.
+<sup>[[link](#no-multiline-while-do)]</sup>
 
   ```Ruby
   # bad
@@ -860,8 +955,9 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Favor modifier `while/until` usage when you have a single-line
-  body.
+* <a name="while-as-a-modifier"></a>
+  Favor modifier `while/until` usage when you have a single-line body.
+<sup>[[link](#while-as-a-modifier)]</sup>
 
   ```Ruby
   # bad
@@ -873,7 +969,9 @@ Translations of the guide are available in the following languages:
   do_something while some_condition
   ```
 
-* Favor `until` over `while` for negative conditions.
+* <a name="until-for-negatives"></a>
+  Favor `until` over `while` for negative conditions.
+<sup>[[link](#until-for-negatives)]</sup>
 
   ```Ruby
   # bad
@@ -883,7 +981,9 @@ Translations of the guide are available in the following languages:
   do_something until some_condition
   ```
 
-* Use `Kernel#loop` instead of `while/until` when you need an infinite loop.
+* <a name="infinite-loop"></a>
+  Use `Kernel#loop` instead of `while/until` when you need an infinite loop.
+<sup>[[link](#infinite-loop)]</sup>
 
     ```ruby
     # bad
@@ -901,7 +1001,10 @@ Translations of the guide are available in the following languages:
     end
     ```
 
-* Use `Kernel#loop` with `break` rather than `begin/end/until` or `begin/end/while` for post-loop tests.
+* <a name="loop-with-break"></a>
+  Use `Kernel#loop` with `break` rather than `begin/end/until` or
+  `begin/end/while` for post-loop tests.
+<sup>[[link](#loop-with-break)]</sup>
 
   ```Ruby
   # bad
@@ -918,11 +1021,12 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Omit parentheses around parameters for methods that are part of an
-  internal DSL (e.g. Rake, Rails, RSpec), methods that have
-  "keyword" status in Ruby (e.g. `attr_reader`, `puts`) and attribute
-  access methods. Use parentheses around the arguments of all other
-  method invocations.
+* <a name="no-dsl-parens"></a>
+  Omit parentheses around parameters for methods that are part of an internal
+  DSL (e.g. Rake, Rails, RSpec), methods that have "keyword" status in Ruby
+  (e.g. `attr_reader`, `puts`) and attribute access methods. Use parentheses
+  around the arguments of all other method invocations.
+<sup>[[link](#no-dsl-parens)]</sup>
 
   ```Ruby
   class Person
@@ -942,7 +1046,9 @@ Translations of the guide are available in the following languages:
   bowling.score.should == 0
   ```
 
-* Omit the outer braces around an implicit options hash.
+* <a name="no-braces-opts-hash"></a>
+  Omit the outer braces around an implicit options hash.
+<sup>[[link](#no-braces-opts-hash)]</sup>
 
   ```Ruby
   # bad
@@ -952,8 +1058,10 @@ Translations of the guide are available in the following languages:
   user.set(name: 'John', age: 45, permissions: { read: true })
   ```
 
-* Omit both the outer braces and parentheses for methods that are
-  part of an internal DSL.
+* <a name="no-dsl-decorating"></a>
+  Omit both the outer braces and parentheses for methods that are part of an
+  internal DSL.
+<sup>[[link](#no-dsl-decorating)]</sup>
 
   ```Ruby
   class Person < ActiveRecord::Base
@@ -965,7 +1073,9 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Omit parentheses for method calls with no arguments.
+* <a name="no-args-no-parens"></a>
+  Omit parentheses for method calls with no arguments.
+<sup>[[link](#no-args-no-parens)]</sup>
 
   ```Ruby
   # bad
@@ -981,11 +1091,12 @@ Translations of the guide are available in the following languages:
   'test'.upcase
   ```
 
-* Prefer `{...}` over `do...end` for single-line blocks.  Avoid using
-  `{...}` for multi-line blocks (multiline chaining is always
-  ugly). Always use `do...end` for "control flow" and "method
-  definitions" (e.g. in Rakefiles and certain DSLs).  Avoid `do...end`
-  when chaining.
+* <a name="single-line-blocks"></a>
+  Prefer `{...}` over `do...end` for single-line blocks.  Avoid using `{...}`
+  for multi-line blocks (multiline chaining is always ugly). Always use
+  `do...end` for "control flow" and "method definitions" (e.g. in Rakefiles and
+  certain DSLs).  Avoid `do...end` when chaining.
+<sup>[[link](#single-line-blocks)]</sup>
 
   ```Ruby
   names = ['Bozhidar', 'Steve', 'Sarah']
@@ -1011,10 +1122,11 @@ Translations of the guide are available in the following languages:
   ask themselves - is this code really readable and can the blocks' contents be extracted into
   nifty methods?
 
-* Consider using explicit block argument to avoid writing block
-  literal that just passes its arguments to another block. Beware of
-  the performance impact, though, as the block gets converted to a
-  Proc.
+* <a name="block-argument"></a>
+  Consider using explicit block argument to avoid writing block literal that
+  just passes its arguments to another block. Beware of the performance impact,
+  though, as the block gets converted to a Proc.
+<sup>[[link](#block-argument)]</sup>
 
   ```Ruby
   require 'tempfile'
@@ -1038,7 +1150,9 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Avoid `return` where not required for flow of control.
+* <a name="no-explicit-return"></a>
+  Avoid `return` where not required for flow of control.
+<sup>[[link](#no-explicit-return)]</sup>
 
   ```Ruby
   # bad
@@ -1052,7 +1166,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Avoid `self` where not required. (It is only required when calling a self write accessor.)
+* <a name="no-self-unless-required"></a>
+  Avoid `self` where not required. (It is only required when calling a self
+  write accessor.)
+<sup>[[link](#no-self-unless-required)]</sup>
 
   ```Ruby
   # bad
@@ -1074,7 +1191,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* As a corollary, avoid shadowing methods with local variables unless they are both equivalent.
+* <a name="no-shadowing"></a>
+  As a corollary, avoid shadowing methods with local variables unless they are
+  both equivalent.
+<sup>[[link](#no-shadowing)]</sup>
 
   ```Ruby
   class Foo
@@ -1102,10 +1222,12 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Don't use the return value of `=` (an assignment) in conditional
-  expressions unless the assignment is wrapped in parentheses. This is
-  a fairly popular idiom among Rubyists that's sometimes referred to as
-  *safe assignment in condition*.
+* <a name="safe-assignment-in-condition"></a>
+  Don't use the return value of `=` (an assignment) in conditional expressions
+  unless the assignment is wrapped in parentheses. This is a fairly popular
+  idiom among Rubyists that's sometimes referred to as *safe assignment in
+  condition*.
+<sup>[[link](#safe-assignment-in-condition)]</sup>
 
   ```Ruby
   # bad (+ a warning)
@@ -1128,7 +1250,9 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Use shorthand self assignment operators whenever applicable.
+* <a name="self-assignment"></a>
+  Use shorthand self assignment operators whenever applicable.
+<sup>[[link](#self-assignment)]</sup>
 
   ```Ruby
   # bad
@@ -1148,7 +1272,9 @@ Translations of the guide are available in the following languages:
   x &&= y
   ```
 
-* Use `||=` to initialize variables only if they're not already initialized.
+* <a name="double-pipe-for-uninit"></a>
+  Use `||=` to initialize variables only if they're not already initialized.
+<sup>[[link](#double-pipe-for-uninit)]</sup>
 
   ```Ruby
   # bad
@@ -1161,8 +1287,10 @@ Translations of the guide are available in the following languages:
   name ||= 'Bozhidar'
   ```
 
-* Don't use `||=` to initialize boolean variables. (Consider what
-  would happen if the current value happened to be `false`.)
+* <a name="no-double-pipes-for-bools"></a>
+  Don't use `||=` to initialize boolean variables. (Consider what would happen
+  if the current value happened to be `false`.)
+<sup>[[link](#no-double-pipes-for-bools)]</sup>
 
   ```Ruby
   # bad - would set enabled to true even if it was false
@@ -1172,9 +1300,11 @@ Translations of the guide are available in the following languages:
   enabled = true if enabled.nil?
   ```
 
-* Use `&&=` to preprocess variables that may or may not exist. Using
-  `&&=` will change the value only if it exists, removing the need to
-  check its existence with `if`.
+* <a name="double-amper-preprocess"></a>
+  Use `&&=` to preprocess variables that may or may not exist. Using `&&=`
+  will change the value only if it exists, removing the need to check its
+  existence with `if`.
+<sup>[[link](#double-amper-preprocess)]</sup>
 
   ```Ruby
   # bad
@@ -1195,9 +1325,11 @@ Translations of the guide are available in the following languages:
   something &&= something.downcase
   ```
 
-* Avoid explicit use of the case equality operator `===`. As its name
-  implies it is meant to be used implicitly by `case` expressions and
-  outside of them it yields some pretty confusing code.
+* <a name="no-case-equality"></a>
+  Avoid explicit use of the case equality operator `===`. As its name implies
+  it is meant to be used implicitly by `case` expressions and outside of them it
+  yields some pretty confusing code.
+<sup>[[link](#no-case-equality)]</sup>
 
   ```Ruby
   # bad
@@ -1211,10 +1343,11 @@ Translations of the guide are available in the following languages:
   some_string =~ /something/
   ```
 
-* Avoid using Perl-style special variables (like `$:`, `$;`,
-  etc. ). They are quite cryptic and their use in anything but
-  one-liner scripts is discouraged. Use the human-friendly
-  aliases provided by the `English` library.
+* <a name="no-cryptic-perlisms"></a>
+  Avoid using Perl-style special variables (like `$:`, `$;`, etc. ). They are
+  quite cryptic and their use in anything but one-liner scripts is discouraged.
+  Use the human-friendly aliases provided by the `English` library.
+<sup>[[link](#no-cryptic-perlisms)]</sup>
 
   ```Ruby
   # bad
@@ -1225,7 +1358,9 @@ Translations of the guide are available in the following languages:
   $LOAD_PATH.unshift File.dirname(__FILE__)
   ```
 
-* Never put a space between a method name and the opening parenthesis.
+* <a name="parens-no-spaces"></a>
+  Never put a space between a method name and the opening parenthesis.
+<sup>[[link](#parens-no-spaces)]</sup>
 
   ```Ruby
   # bad
@@ -1235,15 +1370,20 @@ Translations of the guide are available in the following languages:
   f(3 + 2) + 1
   ```
 
-* If the first argument to a method begins with an open parenthesis,
-  always use parentheses in the method invocation. For example, write
-  `f((3 + 2) + 1)`.
+* <a name="parens-as-args"></a>
+  If the first argument to a method begins with an open parenthesis, always
+  use parentheses in the method invocation. For example, write `f((3 + 2) + 1)`.
+<sup>[[link](#parens-as-args)]</sup>
 
-* Always run the Ruby interpreter with the `-w` option so it will warn
-  you if you forget either of the rules above!
+* <a name="always-warn-at-runtime"></a>
+  Always run the Ruby interpreter with the `-w` option so it will warn you if
+  you forget either of the rules above!
+<sup>[[link](#always-warn-at-runtime)]</sup>
 
-* Use the new lambda literal syntax for single line body blocks. Use the
+* <a name="lambda-multi-line"></a>
+  Use the new lambda literal syntax for single line body blocks. Use the
   `lambda` method for multi-line blocks.
+<sup>[[link](#lambda-multi-line)]</sup>
 
   ```Ruby
   # bad
@@ -1266,7 +1406,9 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Prefer `proc` over `Proc.new`.
+* <a name="proc"></a>
+  Prefer `proc` over `Proc.new`.
+<sup>[[link](#proc)]</sup>
 
   ```Ruby
   # bad
@@ -1276,7 +1418,9 @@ Translations of the guide are available in the following languages:
   p = proc { |n| puts n }
   ```
 
-* Prefer `proc.call()` over `proc[]` or `proc.()` for both lambdas and procs.
+* <a name="proc-call"></a>
+  Prefer `proc.call()` over `proc[]` or `proc.()` for both lambdas and procs.
+<sup>[[link](#proc-call)]</sup>
 
   ```Ruby
   # bad - looks similar to Enumeration access
@@ -1292,10 +1436,12 @@ Translations of the guide are available in the following languages:
   l.call(1)
   ```
 
-* Prefix with `_` unused block parameters and local variables. It's
-  also acceptable to use just `_` (although it's a bit less
-  descriptive). This convention is recognized by the Ruby interpreter
-  and tools like RuboCop and will suppress their unused variable warnings.
+* <a name="underscore-unused-vars"></a>
+  Prefix with `_` unused block parameters and local variables. It's also
+  acceptable to use just `_` (although it's a bit less descriptive). This
+  convention is recognized by the Ruby interpreter and tools like RuboCop and
+  will suppress their unused variable warnings.
+<sup>[[link](#underscore-unused-vars)]</sup>
 
   ```Ruby
   # bad
@@ -1323,17 +1469,23 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Use `$stdout/$stderr/$stdin` instead of
-  `STDOUT/STDERR/STDIN`. `STDOUT/STDERR/STDIN` are constants, and
-  while you can actually reassign (possibly to redirect some stream)
-  constants in Ruby, you'll get an interpreter warning if you do so.
+* <a name="global-stdout"></a>
+  Use `$stdout/$stderr/$stdin` instead of `STDOUT/STDERR/STDIN`.
+  `STDOUT/STDERR/STDIN` are constants, and while you can actually reassign
+  (possibly to redirect some stream) constants in Ruby, you'll get an
+  interpreter warning if you do so.
+<sup>[[link](#global-stdout)]</sup>
 
-* Use `warn` instead of `$stderr.puts`. Apart from being more concise
-  and clear, `warn` allows you to suppress warnings if you need to (by
-  setting the warn level to 0 via `-W0`).
+* <a name="warn"></a>
+  Use `warn` instead of `$stderr.puts`. Apart from being more concise and
+  clear, `warn` allows you to suppress warnings if you need to (by setting the
+  warn level to 0 via `-W0`).
+<sup>[[link](#warn)]</sup>
 
-* Favor the use of `sprintf` and its alias `format` over the fairly
-  cryptic `String#%` method.
+* <a name="sprintf"></a>
+  Favor the use of `sprintf` and its alias `format` over the fairly cryptic
+  `String#%` method.
+<sup>[[link](#sprintf)]</sup>
 
   ```Ruby
   # bad
@@ -1356,7 +1508,9 @@ Translations of the guide are available in the following languages:
   # => '20 10'
   ```
 
-* Favor the use of `Array#join` over the fairly cryptic `Array#*` with
+* <a name="array-join"></a>
+  Favor the use of `Array#join` over the fairly cryptic `Array#*` with
+<sup>[[link](#array-join)]</sup>
   a string argument.
 
   ```Ruby
@@ -1369,9 +1523,11 @@ Translations of the guide are available in the following languages:
   # => 'one, two, three'
   ```
 
-* Use `[*var]` or `Array()` instead of explicit `Array` check, when dealing with a
-  variable you want to treat as an Array, but you're not certain it's
-  an array.
+* <a name="splat-arrays"></a>
+  Use `[*var]` or `Array()` instead of explicit `Array` check, when dealing
+  with a variable you want to treat as an Array, but you're not certain it's an
+  array.
+<sup>[[link](#splat-arrays)]</sup>
 
   ```Ruby
   # bad
@@ -1385,7 +1541,10 @@ Translations of the guide are available in the following languages:
   Array(paths).each { |path| do_something(path) }
   ```
 
-* Use ranges or `Comparable#between?` instead of complex comparison logic when possible.
+* <a name="ranges-or-between"></a>
+  Use ranges or `Comparable#between?` instead of complex comparison logic when
+  possible.
+<sup>[[link](#ranges-or-between)]</sup>
 
   ```Ruby
   # bad
@@ -1398,8 +1557,10 @@ Translations of the guide are available in the following languages:
   do_something if x.between?(1000, 2000)
   ```
 
-* Favor the use of predicate methods to explicit comparisons with
-  `==`. Numeric comparisons are OK.
+* <a name="predicate-methods"></a>
+  Favor the use of predicate methods to explicit comparisons with `==`.
+  Numeric comparisons are OK.
+<sup>[[link](#predicate-methods)]</sup>
 
   ```Ruby
   # bad
@@ -1429,7 +1590,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Don't do explicit non-`nil` checks unless you're dealing with boolean values.
+* <a name="no-non-nil-checks"></a>
+  Don't do explicit non-`nil` checks unless you're dealing with boolean
+  values.
+<sup>[[link](#no-non-nil-checks)]</sup>
 
     ```ruby
     # bad
@@ -1445,9 +1609,13 @@ Translations of the guide are available in the following languages:
     end
     ```
 
-* Avoid the use of `BEGIN` blocks.
+* <a name="no-BEGIN-blocks"></a>
+  Avoid the use of `BEGIN` blocks.
+<sup>[[link](#no-BEGIN-blocks)]</sup>
 
-* Never use `END` blocks. Use `Kernel#at_exit` instead.
+* <a name="no-END-blocks"></a>
+  Never use `END` blocks. Use `Kernel#at_exit` instead.
+<sup>[[link](#no-END-blocks)]</sup>
 
   ```ruby
   # bad
@@ -1457,9 +1625,13 @@ Translations of the guide are available in the following languages:
   at_exit { puts 'Goodbye!' }
   ```
 
-* Avoid the use of flip-flops.
+* <a name="no-flip-flops"></a>
+  Avoid the use of flip-flops.
+<sup>[[link](#no-flip-flops)]</sup>
 
-* Avoid use of nested conditionals for flow of control.
+* <a name="no-nested-conditionals"></a>
+  Avoid use of nested conditionals for flow of control.
+<sup>[[link](#no-nested-conditionals)]</sup>
 
   Prefer a guard clause when you can assert invalid data. A guard clause
   is a conditional statement at the top of a function that bails out as
@@ -1510,7 +1682,9 @@ Translations of the guide are available in the following languages:
 > naming things. <br/>
 > -- Phil Karlton
 
-* Name identifiers in English.
+* <a name="english-identifiers"></a>
+  Name identifiers in English.
+<sup>[[link](#english-identifiers)]</sup>
 
   ```Ruby
   # bad - identifier using non-ascii characters
@@ -1523,7 +1697,9 @@ Translations of the guide are available in the following languages:
   salary = 1_000
   ```
 
-* Use `snake_case` for symbols, methods and variables.
+* <a name="snake-case-symbols-methods-vars"></a>
+  Use `snake_case` for symbols, methods and variables.
+<sup>[[link](#snake-case-symbols-methods-vars)]</sup>
 
   ```Ruby
   # bad
@@ -1549,8 +1725,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Use `CamelCase` for classes and modules.  (Keep acronyms like HTTP,
-  RFC, XML uppercase.)
+* <a name="camelcase-classes"></a>
+  Use `CamelCase` for classes and modules.  (Keep acronyms like HTTP, RFC, XML
+  uppercase.)
+<sup>[[link](#camelcase-classes)]</sup>
 
   ```Ruby
   # bad
@@ -1576,14 +1754,23 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Use `snake_case` for naming files, e.g. `hello_world.rb`.
+* <a name="snake-case-files"></a>
+  Use `snake_case` for naming files, e.g. `hello_world.rb`.
+<sup>[[link](#snake-case-files)]</sup>
 
-* Use `snake_case` for naming directories, e.g. `lib/hello_world/hello_world.rb`.
+* <a name="snake-case-dirs"></a>
+  Use `snake_case` for naming directories, e.g.
+  `lib/hello_world/hello_world.rb`.
+<sup>[[link](#snake-case-dirs)]</sup>
 
-* Aim to have just a single class/module per source file. Name the file name as
-  the class/module, but replacing CamelCase with snake_case.
+* <a name="one-class-per-file"></a>
+  Aim to have just a single class/module per source file. Name the file name
+  as the class/module, but replacing CamelCase with snake_case.
+<sup>[[link](#one-class-per-file)]</sup>
 
-* Use `SCREAMING_SNAKE_CASE` for other constants.
+* <a name="screaming-snake-case"></a>
+  Use `SCREAMING_SNAKE_CASE` for other constants.
+<sup>[[link](#screaming-snake-case)]</sup>
 
   ```Ruby
   # bad
@@ -1593,15 +1780,18 @@ Translations of the guide are available in the following languages:
   SOME_CONST = 5
   ```
 
-* The names of predicate methods (methods that return a boolean value)
-  should end in a question mark.
-  (i.e. `Array#empty?`). Methods that don't return a boolean, shouldn't
-  end in a question mark.
+* <a name="bool-methods-qmark"></a>
+  The names of predicate methods (methods that return a boolean value) should
+  end in a question mark.  (i.e. `Array#empty?`). Methods that don't return a
+  boolean, shouldn't end in a question mark.
+<sup>[[link](#bool-methods-qmark)]</sup>
 
-* The names of potentially *dangerous* methods (i.e. methods that
-  modify `self` or the arguments, `exit!` (doesn't run the finalizers
-  like `exit` does), etc.) should end with an exclamation mark if
-  there exists a safe version of that *dangerous* method.
+* <a name="dangerous-method-bang"></a>
+  The names of potentially *dangerous* methods (i.e. methods that modify
+  `self` or the arguments, `exit!` (doesn't run the finalizers like `exit`
+  does), etc.) should end with an exclamation mark if there exists a safe
+  version of that *dangerous* method.
+<sup>[[link](#dangerous-method-bang)]</sup>
 
   ```Ruby
   # bad - there is no matching 'safe' method
@@ -1626,8 +1816,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Define the non-bang (safe) method in terms of the bang (dangerous)
-  one if possible.
+* <a name="safe-because-unsafe"></a>
+  Define the non-bang (safe) method in terms of the bang (dangerous) one if
+  possible.
+<sup>[[link](#safe-because-unsafe)]</sup>
 
   ```Ruby
   class Array
@@ -1647,11 +1839,15 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* When using `reduce` with short blocks, name the arguments `|a, e|`
+* <a name="reduce-blocks"></a>
+  When using `reduce` with short blocks, name the arguments `|a, e|`
   (accumulator, element).
+<sup>[[link](#reduce-blocks)]</sup>
 
-* When defining binary operators, name the argument `other`(`<<` and
-  `[]` are exceptions to the rule, since their semantics are different).
+* <a name="other-arg"></a>
+  When defining binary operators, name the argument `other`(`<<` and `[]` are
+  exceptions to the rule, since their semantics are different).
+<sup>[[link](#other-arg)]</sup>
 
   ```Ruby
   def +(other)
@@ -1659,17 +1855,21 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Prefer `map` over `collect`, `find` over `detect`, `select` over
-  `find_all`, `reduce` over `inject` and `size` over `length`. This is
-  not a hard requirement; if the use of the alias enhances
-  readability, it's ok to use it. The rhyming methods are inherited from
-  Smalltalk and are not common in other programming languages. The
-  reason the use of `select` is encouraged over `find_all` is that it
-  goes together nicely with `reject` and its name is pretty self-explanatory.
+* <a name="map-fine-select-reduce-size"></a>
+  Prefer `map` over `collect`, `find` over `detect`, `select` over `find_all`,
+  `reduce` over `inject` and `size` over `length`. This is not a hard
+  requirement; if the use of the alias enhances readability, it's ok to use it.
+  The rhyming methods are inherited from Smalltalk and are not common in other
+  programming languages. The reason the use of `select` is encouraged over
+  `find_all` is that it goes together nicely with `reject` and its name is
+  pretty self-explanatory.
+<sup>[[link](#map-fine-select-reduce-size)]</sup>
 
-* Don't use `count` as a substitute for `size`. For `Enumerable`
-  objects other than `Array` it will iterate the entire collection in
-  order to determine its size.
+* <a name="count-vs-size"></a>
+  Don't use `count` as a substitute for `size`. For `Enumerable` objects other
+  than `Array` it will iterate the entire collection in order to determine its
+  size.
+<sup>[[link](#count-vs-size)]</sup>
 
   ```Ruby
   # bad
@@ -1679,10 +1879,12 @@ Translations of the guide are available in the following languages:
   some_hash.size
   ```
 
-* Use `flat_map` instead of `map` + `flatten`.
-  This does not apply for arrays with a depth greater than 2, i.e.
-  if `users.first.songs == ['a', ['b','c']]`, then use `map + flatten` rather than `flat_map`.
-  `flat_map` flattens the array by 1, whereas `flatten` flattens it all the way.
+* <a name="flat-map"></a>
+  Use `flat_map` instead of `map` + `flatten`.  This does not apply for arrays
+  with a depth greater than 2, i.e.  if `users.first.songs == ['a', ['b','c']]`,
+  then use `map + flatten` rather than `flat_map`.  `flat_map` flattens the
+  array by 1, whereas `flatten` flattens it all the way.
+<sup>[[link](#flat-map)]</sup>
 
   ```Ruby
   # bad
@@ -1692,8 +1894,10 @@ Translations of the guide are available in the following languages:
   all_songs = users.flat_map(&:songs).uniq
   ```
 
-* Use `reverse_each` instead of `reverse.each`. `reverse_each` doesn't
-  do a new array allocation and that's a good thing.
+* <a name="reverse-each"></a>
+  Use `reverse_each` instead of `reverse.each`. `reverse_each` doesn't do a
+  new array allocation and that's a good thing.
+<sup>[[link](#reverse-each)]</sup>
 
   ```Ruby
   # bad
@@ -1711,42 +1915,62 @@ Translations of the guide are available in the following languages:
 > it even clearer. <br/>
 > -- Steve McConnell
 
-* Write self-documenting code and ignore the rest of this section. Seriously!
+* <a name="no-comments"></a>
+  Write self-documenting code and ignore the rest of this section. Seriously!
+<sup>[[link](#no-comments)]</sup>
 
-* Write comments in English.
+* <a name="english-comments"></a>
+  Write comments in English.
+<sup>[[link](#english-comments)]</sup>
 
-* Use one space between the leading `#` character of the comment and the text
+* <a name="hash-space"></a>
+  Use one space between the leading `#` character of the comment and the text
   of the comment.
+<sup>[[link](#hash-space)]</sup>
 
-* Comments longer than a word are capitalized and use punctuation. Use [one
+* <a name="english-syntax"></a>
+  Comments longer than a word are capitalized and use punctuation. Use [one
   space](http://en.wikipedia.org/wiki/Sentence_spacing) after periods.
+<sup>[[link](#english-syntax)]</sup>
 
-* Avoid superfluous comments.
+* <a name="no-superfluous-comments"></a>
+  Avoid superfluous comments.
+<sup>[[link](#no-superfluous-comments)]</sup>
 
   ```Ruby
   # bad
   counter += 1 # Increments counter by one.
   ```
 
-* Keep existing comments up-to-date. An outdated comment is worse than no comment
-  at all.
+* <a name="comment-upkeep"></a>
+  Keep existing comments up-to-date. An outdated comment is worse than no
+  comment at all.
+<sup>[[link](#comment-upkeep)]</sup>
 
 > Good code is like a good joke - it needs no explanation. <br/>
 > -- Russ Olsen
 
-* Avoid writing comments to explain bad code. Refactor the code to
-  make it self-explanatory. (Do or do not - there is no try. --Yoda)
+* <a name="refactor-dont-comment"></a>
+  Avoid writing comments to explain bad code. Refactor the code to make it
+  self-explanatory. (Do or do not - there is no try. --Yoda)
+<sup>[[link](#refactor-dont-comment)]</sup>
 
 ### Comment Annotations
 
-* Annotations should usually be written on the line immediately above
-  the relevant code.
+* <a name="annotate-above"></a>
+  Annotations should usually be written on the line immediately above the
+  relevant code.
+<sup>[[link](#annotate-above)]</sup>
 
-* The annotation keyword is followed by a colon and a space, then a note
+* <a name="annotate-keywords"></a>
+  The annotation keyword is followed by a colon and a space, then a note
   describing the problem.
+<sup>[[link](#annotate-keywords)]</sup>
 
-* If multiple lines are required to describe the problem, subsequent
-  lines should be indented two spaces after the `#`.
+* <a name="indent-annotations"></a>
+  If multiple lines are required to describe the problem, subsequent lines
+  should be indented two spaces after the `#`.
+<sup>[[link](#indent-annotations)]</sup>
 
   ```Ruby
   def bar
@@ -1756,9 +1980,11 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* In cases where the problem is so obvious that any documentation would
-  be redundant, annotations may be left at the end of the offending line
-  with no note. This usage should be the exception and not the rule.
+* <a name="rare-eol-annotations"></a>
+  In cases where the problem is so obvious that any documentation would be
+  redundant, annotations may be left at the end of the offending line with no
+  note. This usage should be the exception and not the rule.
+<sup>[[link](#rare-eol-annotations)]</sup>
 
   ```Ruby
   def bar
@@ -1766,27 +1992,41 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Use `TODO` to note missing features or functionality that should be
-  added at a later date.
+* <a name="todo"></a>
+  Use `TODO` to note missing features or functionality that should be added at
+  a later date.
+<sup>[[link](#todo)]</sup>
 
-* Use `FIXME` to note broken code that needs to be fixed.
+* <a name="fixme"></a>
+  Use `FIXME` to note broken code that needs to be fixed.
+<sup>[[link](#fixme)]</sup>
 
-* Use `OPTIMIZE` to note slow or inefficient code that may cause
-  performance problems.
+* <a name="optimize"></a>
+  Use `OPTIMIZE` to note slow or inefficient code that may cause performance
+  problems.
+<sup>[[link](#optimize)]</sup>
 
-* Use `HACK` to note code smells where questionable coding practices
-  were used and should be refactored away.
+* <a name="hack"></a>
+  Use `HACK` to note code smells where questionable coding practices were used
+  and should be refactored away.
+<sup>[[link](#hack)]</sup>
 
-* Use `REVIEW` to note anything that should be looked at to confirm it
-  is working as intended. For example: `REVIEW: Are we sure this is how the
-  client does X currently?`
+* <a name="review"></a>
+  Use `REVIEW` to note anything that should be looked at to confirm it is
+  working as intended. For example: `REVIEW: Are we sure this is how the client
+  does X currently?`
+<sup>[[link](#review)]</sup>
 
-* Use other custom annotation keywords if it feels appropriate, but be
-  sure to document them in your project's `README` or similar.
+* <a name="document-annotations"></a>
+  Use other custom annotation keywords if it feels appropriate, but be sure to
+  document them in your project's `README` or similar.
+<sup>[[link](#document-annotations)]</sup>
 
 ## Classes & Modules
 
-* Use a consistent structure in your class definitions.
+* <a name="consistent-classes"></a>
+  Use a consistent structure in your class definitions.
+<sup>[[link](#consistent-classes)]</sup>
 
   ```Ruby
   class Person
@@ -1827,8 +2067,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Don't nest multi line classes within classes. Try to have such nested
+* <a name="file-classes"></a>
+  Don't nest multi line classes within classes. Try to have such nested
   classes each in their own file in a folder named like the containing class.
+<sup>[[link](#file-classes)]</sup>
 
   ```Ruby
   # bad
@@ -1868,8 +2110,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Prefer modules to classes with only class methods. Classes should be
-  used only when it makes sense to create instances out of them.
+* <a name="modules-vs-classes"></a>
+  Prefer modules to classes with only class methods. Classes should be used
+  only when it makes sense to create instances out of them.
+<sup>[[link](#modules-vs-classes)]</sup>
 
   ```Ruby
   # bad
@@ -1895,8 +2139,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Favor the use of `module_function` over `extend self` when you want
-  to turn a module's instance methods into class methods.
+* <a name="module-function"></a>
+  Favor the use of `module_function` over `extend self` when you want to turn
+  a module's instance methods into class methods.
+<sup>[[link](#module-function)]</sup>
 
   ```Ruby
   # bad
@@ -1926,15 +2172,22 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* When designing class hierarchies make sure that they conform to the
-  [Liskov Substitution Principle](http://en.wikipedia.org/wiki/Liskov_substitution_principle).
+* <a name="liskov"></a>
+  When designing class hierarchies make sure that they conform to the [Liskov
+  Substitution
+  Principle](http://en.wikipedia.org/wiki/Liskov_substitution_principle).
+<sup>[[link](#liskov)]</sup>
 
-* Try to make your classes as
-  [SOLID](http://en.wikipedia.org/wiki/SOLID_\(object-oriented_design\))
-  as possible.
+* <a name="solid-design"></a>
+  Try to make your classes as
+  [SOLID](http://en.wikipedia.org/wiki/SOLID_\(object-oriented_design\)) as
+  possible.
+<sup>[[link](#solid-design)]</sup>
 
-* Always supply a proper `to_s` method for classes that represent
-  domain objects.
+* <a name="define-to-s"></a>
+  Always supply a proper `to_s` method for classes that represent domain
+  objects.
+<sup>[[link](#define-to-s)]</sup>
 
   ```Ruby
   class Person
@@ -1951,7 +2204,9 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Use the `attr` family of functions to define trivial accessors or mutators.
+* <a name="attr_family"></a>
+  Use the `attr` family of functions to define trivial accessors or mutators.
+<sup>[[link](#attr_family)]</sup>
 
   ```Ruby
   # bad
@@ -1981,7 +2236,9 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Avoid the use of `attr`. Use `attr_reader` and `attr_accessor` instead.
+* <a name="attr"></a>
+  Avoid the use of `attr`. Use `attr_reader` and `attr_accessor` instead.
+<sup>[[link](#attr)]</sup>
 
   ```Ruby
   # bad - creates a single attribute accessor (deprecated in 1.9)
@@ -1993,8 +2250,10 @@ Translations of the guide are available in the following languages:
   attr_reader :one, :two, :three
   ```
 
-* Consider using `Struct.new`, which defines the trivial accessors,
+* <a name="struct-new"></a>
+  Consider using `Struct.new`, which defines the trivial accessors,
   constructor and comparison operators for you.
+<sup>[[link](#struct-new)]</sup>
 
   ```Ruby
   # good
@@ -2012,12 +2271,16 @@ Translations of the guide are available in the following languages:
   end
   ````
 
-* Don't extend a `Struct.new` - it already is a new class. Extending it introduces
-  a superfluous class level and may also introduce weird errors if the file is
-  required multiple times.
+* <a name="no-extend-struct-new"></a>
+  Don't extend a `Struct.new` - it already is a new class. Extending it
+  introduces a superfluous class level and may also introduce weird errors if
+  the file is required multiple times.
+<sup>[[link](#no-extend-struct-new)]</sup>
 
-* Consider adding factory methods to provide additional sensible ways
-  to create instances of a particular class.
+* <a name="factory-methods"></a>
+  Consider adding factory methods to provide additional sensible ways to
+  create instances of a particular class.
+<sup>[[link](#factory-methods)]</sup>
 
   ```Ruby
   class Person
@@ -2027,7 +2290,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Prefer [duck-typing](http://en.wikipedia.org/wiki/Duck_typing) over inheritance.
+* <a name="duck-typing"></a>
+  Prefer [duck-typing](http://en.wikipedia.org/wiki/Duck_typing) over
+  inheritance.
+<sup>[[link](#duck-typing)]</sup>
 
   ```Ruby
   # bad
@@ -2065,7 +2331,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Avoid the usage of class (`@@`) variables due to their "nasty" behavior in inheritance.
+* <a name="no-class-vars"></a>
+  Avoid the usage of class (`@@`) variables due to their "nasty" behavior in
+  inheritance.
+<sup>[[link](#no-class-vars)]</sup>
 
   ```Ruby
   class Parent
@@ -2087,16 +2356,18 @@ Translations of the guide are available in the following languages:
   class variable. Class instance variables should usually be preferred
   over class variables.
 
-* Assign proper visibility levels to methods (`private`, `protected`)
-  in accordance with their intended usage. Don't go off leaving
-  everything `public` (which is the default). After all we're coding
-  in *Ruby* now, not in *Python*.
+* <a name="visibility"></a>
+  Assign proper visibility levels to methods (`private`, `protected`) in
+  accordance with their intended usage. Don't go off leaving everything `public`
+  (which is the default). After all we're coding in *Ruby* now, not in *Python*.
+<sup>[[link](#visibility)]</sup>
 
-* Indent the `public`, `protected`, and `private` methods as much the
-  method definitions they apply to. Leave one blank line above the
-  visibility modifier
-  and one blank line below in order to emphasize that it applies to all
-  methods below it.
+* <a name="indent-public-private-protected"></a>
+  Indent the `public`, `protected`, and `private` methods as much the method
+  definitions they apply to. Leave one blank line above the visibility modifier
+  and one blank line below in order to emphasize that it applies to all methods
+  below it.
+<sup>[[link](#indent-public-private-protected)]</sup>
 
   ```Ruby
   class SomeClass
@@ -2116,8 +2387,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Use `def self.method` to define singleton methods. This makes the code
+* <a name="def-self-singletons"></a>
+  Use `def self.method` to define singleton methods. This makes the code
   easier to refactor since the class name is not repeated.
+<sup>[[link](#def-self-singletons)]</sup>
 
   ```Ruby
   class TestClass
@@ -2147,9 +2420,11 @@ Translations of the guide are available in the following languages:
 
 ## Exceptions
 
-* Signal exceptions using the `fail` method. Use `raise` only when
-  catching an exception and re-raising it (because here you're not
-  failing, but explicitly and purposefully raising an exception).
+* <a name="fail-method"></a>
+  Signal exceptions using the `fail` method. Use `raise` only when catching an
+  exception and re-raising it (because here you're not failing, but explicitly
+  and purposefully raising an exception).
+<sup>[[link](#fail-method)]</sup>
 
   ```Ruby
   begin
@@ -2159,7 +2434,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Don't specify `RuntimeError` explicitly in the two argument version of `fail/raise`.
+* <a name="no-explicit-runtimeerror"></a>
+  Don't specify `RuntimeError` explicitly in the two argument version of
+  `fail/raise`.
+<sup>[[link](#no-explicit-runtimeerror)]</sup>
 
   ```Ruby
   # bad
@@ -2169,8 +2447,10 @@ Translations of the guide are available in the following languages:
   fail 'message'
   ```
 
-* Prefer supplying an exception class and a message as two separate
-  arguments to `fail/raise`, instead of an exception instance.
+* <a name="exception-class-messages"></a>
+  Prefer supplying an exception class and a message as two separate arguments
+  to `fail/raise`, instead of an exception instance.
+<sup>[[link](#exception-class-messages)]</sup>
 
   ```Ruby
   # bad
@@ -2182,11 +2462,12 @@ Translations of the guide are available in the following languages:
   # Consistent with `fail SomeException, 'message', backtrace`.
   ```
 
-* Never return from an `ensure` block. If you explicitly return from a
-  method inside an `ensure` block, the return will take precedence over
-  any exception being raised, and the method will return as if no
-  exception had been raised at all. In effect, the exception will be
-  silently thrown away.
+* <a name="no-return-ensure"></a>
+  Never return from an `ensure` block. If you explicitly return from a method
+  inside an `ensure` block, the return will take precedence over any exception
+  being raised, and the method will return as if no exception had been raised at
+  all. In effect, the exception will be silently thrown away.
+<sup>[[link](#no-return-ensure)]</sup>
 
   ```Ruby
   def foo
@@ -2198,7 +2479,9 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Use *implicit begin blocks* where possible.
+* <a name="begin-implicit"></a>
+  Use *implicit begin blocks* where possible.
+<sup>[[link](#begin-implicit)]</sup>
 
   ```Ruby
   # bad
@@ -2218,8 +2501,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Mitigate the proliferation of `begin` blocks by using
-  *contingency methods* (a term coined by Avdi Grimm).
+* <a name="contingency-methods"></a>
+  Mitigate the proliferation of `begin` blocks by using *contingency methods*
+  (a term coined by Avdi Grimm).
+<sup>[[link](#contingency-methods)]</sup>
 
   ```Ruby
   # bad
@@ -2247,7 +2532,9 @@ Translations of the guide are available in the following languages:
   with_io_error_handling { something_else_that_might_fail }
   ```
 
-* Don't suppress exceptions.
+* <a name="dont-hide-exceptions"></a>
+  Don't suppress exceptions.
+<sup>[[link](#dont-hide-exceptions)]</sup>
 
   ```Ruby
   # bad
@@ -2261,7 +2548,9 @@ Translations of the guide are available in the following languages:
   do_something rescue nil
   ```
 
-* Avoid using `rescue` in its modifier form.
+* <a name="no-rescue-modifiers"></a>
+  Avoid using `rescue` in its modifier form.
+<sup>[[link](#no-rescue-modifiers)]</sup>
 
   ```Ruby
   # bad - this catches exceptions of StandardError class and its descendant classes
@@ -2275,7 +2564,9 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Don't use exceptions for flow of control.
+* <a name="no-exceptional-flows"></a>
+  Don't use exceptions for flow of control.
+<sup>[[link](#no-exceptional-flows)]</sup>
 
   ```Ruby
   # bad
@@ -2293,8 +2584,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Avoid rescuing the `Exception` class.  This will trap signals and calls to
+* <a name="no-blind-rescues"></a>
+  Avoid rescuing the `Exception` class.  This will trap signals and calls to
   `exit`, requiring you to `kill -9` the process.
+<sup>[[link](#no-blind-rescues)]</sup>
 
   ```Ruby
   # bad
@@ -2323,8 +2616,10 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Put more specific exceptions higher up the rescue chain, otherwise
-  they'll never be rescued from.
+* <a name="exception-ordering"></a>
+  Put more specific exceptions higher up the rescue chain, otherwise they'll
+  never be rescued from.
+<sup>[[link](#exception-ordering)]</sup>
 
   ```Ruby
   # bad
@@ -2346,7 +2641,9 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Release external resources obtained by your program in an ensure block.
+* <a name="file-close"></a>
+  Release external resources obtained by your program in an ensure block.
+<sup>[[link](#file-close)]</sup>
 
   ```Ruby
   f = File.open('testfile')
@@ -2359,13 +2656,17 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Favor the use of exceptions for the standard library over
-  introducing new exception classes.
+* <a name="standard-exceptions"></a>
+  Favor the use of exceptions for the standard library over introducing new
+  exception classes.
+<sup>[[link](#standard-exceptions)]</sup>
 
 ## Collections
 
-* Prefer literal array and hash creation notation (unless you need to
-  pass parameters to their constructors, that is).
+* <a name="literal-array-hash"></a>
+  Prefer literal array and hash creation notation (unless you need to pass
+  parameters to their constructors, that is).
+<sup>[[link](#literal-array-hash)]</sup>
 
   ```Ruby
   # bad
@@ -2377,9 +2678,11 @@ Translations of the guide are available in the following languages:
   hash = {}
   ```
 
-* Prefer `%w` to the literal array syntax when you need an array of
-  words (non-empty strings without spaces and special characters in them).
-  Apply this rule only to arrays with two or more elements.
+* <a name="percent-w"></a>
+  Prefer `%w` to the literal array syntax when you need an array of words
+  (non-empty strings without spaces and special characters in them).  Apply this
+  rule only to arrays with two or more elements.
+<sup>[[link](#percent-w)]</sup>
 
   ```Ruby
   # bad
@@ -2389,9 +2692,11 @@ Translations of the guide are available in the following languages:
   STATES = %w(draft open closed)
   ```
 
-* Prefer `%i` to the literal array syntax when you need an array of
-  symbols (and you don't need to maintain Ruby 1.9 compatibility). Apply
-  this rule only to arrays with two or more elements.
+* <a name="percent-i"></a>
+  Prefer `%i` to the literal array syntax when you need an array of symbols
+  (and you don't need to maintain Ruby 1.9 compatibility). Apply this rule only
+  to arrays with two or more elements.
+<sup>[[link](#percent-i)]</sup>
 
   ```Ruby
   # bad
@@ -2401,8 +2706,10 @@ Translations of the guide are available in the following languages:
   STATES = %i(draft open closed)
   ```
 
-* Avoid comma after the last item of an `Array` or `Hash` literal, especially
+* <a name="no-trailing-array-commas"></a>
+  Avoid comma after the last item of an `Array` or `Hash` literal, especially
   when the items are not on separate lines.
+<sup>[[link](#no-trailing-array-commas)]</sup>
 
   ```Ruby
   # bad - easier to move/add/remove items, but still not preferred
@@ -2419,21 +2726,30 @@ Translations of the guide are available in the following languages:
   VALUES = [1001, 2020, 3333]
   ```
 
-* Avoid the creation of huge gaps in arrays.
+* <a name="no-gappy-arrays"></a>
+  Avoid the creation of huge gaps in arrays.
+<sup>[[link](#no-gappy-arrays)]</sup>
 
   ```Ruby
   arr = []
   arr[100] = 1 # now you have an array with lots of nils
   ```
 
-* When accessing the first or last element from an array, prefer `first` or `last` over `[0]` or `[-1]`.
+* <a name="first-and-last"></a>
+  When accessing the first or last element from an array, prefer `first` or
+  `last` over `[0]` or `[-1]`.
+<sup>[[link](#first-and-last)]</sup>
 
-* Use `Set` instead of `Array` when dealing with unique elements. `Set`
-  implements a collection of unordered values with no duplicates. This
-  is a hybrid of `Array`'s intuitive inter-operation facilities and
-  `Hash`'s fast lookup.
+* <a name="set-vs-array"></a>
+  Use `Set` instead of `Array` when dealing with unique elements. `Set`
+  implements a collection of unordered values with no duplicates. This is a
+  hybrid of `Array`'s intuitive inter-operation facilities and `Hash`'s fast
+  lookup.
+<sup>[[link](#set-vs-array)]</sup>
 
-* Prefer symbols instead of strings as hash keys.
+* <a name="symbols-as-keys"></a>
+  Prefer symbols instead of strings as hash keys.
+<sup>[[link](#symbols-as-keys)]</sup>
 
   ```Ruby
   # bad
@@ -2443,9 +2759,13 @@ Translations of the guide are available in the following languages:
   hash = { one: 1, two: 2, three: 3 }
   ```
 
-* Avoid the use of mutable objects as hash keys.
+* <a name="no-mutable-keys"></a>
+  Avoid the use of mutable objects as hash keys.
+<sup>[[link](#no-mutable-keys)]</sup>
 
-* Use the Ruby 1.9 hash literal syntax when your hash keys are symbols.
+* <a name="hash-literals"></a>
+  Use the Ruby 1.9 hash literal syntax when your hash keys are symbols.
+<sup>[[link](#hash-literals)]</sup>
 
   ```Ruby
   # bad
@@ -2455,9 +2775,11 @@ Translations of the guide are available in the following languages:
   hash = { one: 1, two: 2, three: 3 }
   ```
 
-* Don't mix the Ruby 1.9 hash syntax with hash rockets in the same
-  hash literal. When you've got keys that are not symbols stick to the
-  hash rockets syntax.
+* <a name="no-mixed-hash-syntaces"></a>
+  Don't mix the Ruby 1.9 hash syntax with hash rockets in the same hash
+  literal. When you've got keys that are not symbols stick to the hash rockets
+  syntax.
+<sup>[[link](#no-mixed-hash-syntaces)]</sup>
 
   ```Ruby
   # bad
@@ -2467,10 +2789,12 @@ Translations of the guide are available in the following languages:
   { :a => 1, 'b' => 2 }
   ```
 
-* Use `Hash#key?` instead of `Hash#has_key?` and `Hash#value?` instead
-  of `Hash#has_value?`. As noted
-  [here](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/43765)
-  by Matz, the longer forms are considered deprecated.
+* <a name="hash-key"></a>
+  Use `Hash#key?` instead of `Hash#has_key?` and `Hash#value?` instead of
+  `Hash#has_value?`. As noted
+  [here](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/43765) by
+  Matz, the longer forms are considered deprecated.
+<sup>[[link](#hash-key)]</sup>
 
   ```Ruby
   # bad
@@ -2482,7 +2806,9 @@ Translations of the guide are available in the following languages:
   hash.value?(value)
   ```
 
-* Use `Hash#fetch` when dealing with hash keys that should be present.
+* <a name="hash-fetch"></a>
+  Use `Hash#fetch` when dealing with hash keys that should be present.
+<sup>[[link](#hash-fetch)]</sup>
 
   ```Ruby
   heroes = { batman: 'Bruce Wayne', superman: 'Clark Kent' }
@@ -2494,7 +2820,10 @@ Translations of the guide are available in the following languages:
   heroes.fetch(:supermann)
   ```
 
-* Introduce default values for hash keys via `Hash#fetch` as opposed to using custom logic.
+* <a name="hash-fetch-defaults"></a>
+  Introduce default values for hash keys via `Hash#fetch` as opposed to using
+  custom logic.
+<sup>[[link](#hash-fetch-defaults)]</sup>
 
   ```Ruby
   batman = { name: 'Bruce Wayne', is_evil: false }
@@ -2506,7 +2835,9 @@ Translations of the guide are available in the following languages:
   batman.fetch(:is_evil, true) # => false
   ```
 
-* Prefer the use of the block instead of the default value in `Hash#fetch`.
+* <a name="use-hash-blocks"></a>
+  Prefer the use of the block instead of the default value in `Hash#fetch`.
+<sup>[[link](#use-hash-blocks)]</sup>
 
   ```Ruby
   batman = { name: 'Bruce Wayne' }
@@ -2519,7 +2850,10 @@ Translations of the guide are available in the following languages:
   batman.fetch(:powers) { get_batman_powers }
   ```
 
-* Use `Hash#values_at` when you need to retrieve several values consecutively from a hash.
+* <a name="hash-values-at"></a>
+  Use `Hash#values_at` when you need to retrieve several values consecutively
+  from a hash.
+<sup>[[link](#hash-values-at)]</sup>
 
   ```Ruby
   # bad
@@ -2530,13 +2864,20 @@ Translations of the guide are available in the following languages:
   email, username = data.values_at('email', 'nickname')
   ```
 
-* Rely on the fact that as of Ruby 1.9 hashes are ordered.
+* <a name="ordered-hashes"></a>
+  Rely on the fact that as of Ruby 1.9 hashes are ordered.
+<sup>[[link](#ordered-hashes)]</sup>
 
-* Never modify a collection while traversing it.
+* <a name="no-modifying-collections"></a>
+  Never modify a collection while traversing it.
+<sup>[[link](#no-modifying-collections)]</sup>
 
 ## Strings
 
-* Prefer string interpolation and string formatting instead of string concatenation:
+* <a name="string-interpolation"></a>
+  Prefer string interpolation and string formatting instead of string
+  concatenation:
+<sup>[[link](#string-interpolation)]</sup>
 
   ```Ruby
   # bad
@@ -2549,16 +2890,20 @@ Translations of the guide are available in the following languages:
   email_with_name = format('%s <%s>', user.name, user.email)
   ```
 
-* Consider padding string interpolation code with space. It more clearly sets the
-  code apart from the string.
+* <a name="pad-string-interpolation"></a>
+  Consider padding string interpolation code with space. It more clearly sets
+  the code apart from the string.
+<sup>[[link](#pad-string-interpolation)]</sup>
 
   ```Ruby
   "#{ user.last_name }, #{ user.first_name }"
   ```
 
-* Adopt a consistent string literal quoting style. There are two
-  popular styles in the Ruby community, both of which are considered
-  good - single quotes by default (Option A) and double quotes by default (Option B).
+* <a name="consistent-string-literals"></a>
+  Adopt a consistent string literal quoting style. There are two popular
+  styles in the Ruby community, both of which are considered good - single
+  quotes by default (Option A) and double quotes by default (Option B).
+<sup>[[link](#consistent-string-literals)]</sup>
 
   * **(Option A)** Prefer single-quoted strings when you don't need
     string interpolation or special symbols such as `\t`, `\n`, `'`,
@@ -2587,9 +2932,11 @@ Translations of the guide are available in the following languages:
   community. The string literals in this guide, however, are
   aligned with the first style.
 
-* Don't use the character literal syntax `?x`. Since Ruby 1.9 it's
-  basically redundant - `?x` would interpreted as `'x'` (a string with
-  a single character in it).
+* <a name="no-character-literals"></a>
+  Don't use the character literal syntax `?x`. Since Ruby 1.9 it's basically
+  redundant - `?x` would interpreted as `'x'` (a string with a single character
+  in it).
+<sup>[[link](#no-character-literals)]</sup>
 
   ```Ruby
   # bad
@@ -2599,8 +2946,10 @@ Translations of the guide are available in the following languages:
   char = 'c'
   ```
 
-* Don't leave out `{}` around instance and global variables being
-  interpolated into a string.
+* <a name="curlies-interpolate"></a>
+  Don't leave out `{}` around instance and global variables being interpolated
+  into a string.
+<sup>[[link](#curlies-interpolate)]</sup>
 
   ```Ruby
   class Person
@@ -2630,7 +2979,10 @@ Translations of the guide are available in the following languages:
   puts "$global = #{$global}"
   ```
 
-* Don't use `Object#to_s` on interpolated objects. It's invoked on them automatically.
+* <a name="no-to-s"></a>
+  Don't use `Object#to_s` on interpolated objects. It's invoked on them
+  automatically.
+<sup>[[link](#no-to-s)]</sup>
 
   ```Ruby
   # bad
@@ -2640,9 +2992,12 @@ Translations of the guide are available in the following languages:
   message = "This is the #{result}."
   ```
 
-* Avoid using `String#+` when you need to construct large data chunks.
+* <a name="concat-strings"></a>
+  Avoid using `String#+` when you need to construct large data chunks.
   Instead, use `String#<<`. Concatenation mutates the string instance in-place
-  and is always faster than `String#+`, which creates a bunch of new string objects.
+  and is always faster than `String#+`, which creates a bunch of new string
+  objects.
+<sup>[[link](#concat-strings)]</sup>
 
   ```Ruby
   # good and also fast
@@ -2654,9 +3009,11 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* When using heredocs for multi-line strings keep in mind the fact
-  that they preserve leading whitespace. It's a good practice to
-  employ some margin based on which to trim the excessive whitespace.
+* <a name="heredocs"></a>
+  When using heredocs for multi-line strings keep in mind the fact that they
+  preserve leading whitespace. It's a good practice to employ some margin based
+  on which to trim the excessive whitespace.
+<sup>[[link](#heredocs)]</sup>
 
   ```Ruby
   code = <<-END.gsub(/^\s+\|/, '')
@@ -2674,10 +3031,14 @@ Translations of the guide are available in the following languages:
 > "I know, I'll use regular expressions." Now they have two problems.<br/>
 > -- Jamie Zawinski
 
-* Don't use regular expressions if you just need plain text search in string:
+* <a name="no-regexp-for-plaintext"></a>
+  Don't use regular expressions if you just need plain text search in string:
   `string['text']`
+<sup>[[link](#no-regexp-for-plaintext)]</sup>
 
-* For simple constructions you can use regexp directly through string index.
+* <a name="regexp-string-index"></a>
+  For simple constructions you can use regexp directly through string index.
+<sup>[[link](#regexp-string-index)]</sup>
 
   ```Ruby
   match = string[/regexp/]             # get content of matched regexp
@@ -2685,15 +3046,19 @@ Translations of the guide are available in the following languages:
   string[/text (grp)/, 1] = 'replace'  # string => 'text replace'
   ```
 
-* Use non-capturing groups when you don't use captured result of parentheses.
+* <a name="non-capturing-regexp"></a>
+  Use non-capturing groups when you don't use captured result of parentheses.
+<sup>[[link](#non-capturing-regexp)]</sup>
 
   ```Ruby
   /(first|second)/   # bad
   /(?:first|second)/ # good
   ```
 
-* Don't use the cryptic Perl-legacy variables denoting last regexp group matches
-  (`$1`, `$2`, etc). Use `Regexp.last_match[n]` instead.
+* <a name="no-perl-regexp-last-matchers"></a>
+  Don't use the cryptic Perl-legacy variables denoting last regexp group
+  matches (`$1`, `$2`, etc). Use `Regexp.last_match[n]` instead.
+<sup>[[link](#no-perl-regexp-last-matchers)]</sup>
 
   ```Ruby
   /(regexp)/ =~ string
@@ -2706,8 +3071,10 @@ Translations of the guide are available in the following languages:
   process Regexp.last_match[1]
   ```
 
-* Avoid using numbered groups as it can be hard to track what they contain. Named groups
-  can be used instead.
+* <a name="no-numbered-regexes"></a>
+  Avoid using numbered groups as it can be hard to track what they contain.
+  Named groups can be used instead.
+<sup>[[link](#no-numbered-regexes)]</sup>
 
   ```Ruby
   # bad
@@ -2721,12 +3088,16 @@ Translations of the guide are available in the following languages:
   process meaningful_var
   ```
 
-* Character classes have only a few special characters you should care about:
+* <a name="limit-escapes"></a>
+  Character classes have only a few special characters you should care about:
   `^`, `-`, `\`, `]`, so don't escape `.` or brackets in `[]`.
+<sup>[[link](#limit-escapes)]</sup>
 
-* Be careful with `^` and `$` as they match start/end of line, not string endings.
-  If you want to match the whole string use: `\A` and `\z` (not to be
+* <a name="caret-and-dollar-regexp"></a>
+  Be careful with `^` and `$` as they match start/end of line, not string
+  endings.  If you want to match the whole string use: `\A` and `\z` (not to be
   confused with `\Z` which is the equivalent of `/\n?\z/`).
+<sup>[[link](#caret-and-dollar-regexp)]</sup>
 
   ```Ruby
   string = "some injection\nusername"
@@ -2734,8 +3105,10 @@ Translations of the guide are available in the following languages:
   string[/\Ausername\z/] # doesn't match
   ```
 
-* Use `x` modifier for complex regexps. This makes them more readable and you
+* <a name="comment-regexes"></a>
+  Use `x` modifier for complex regexps. This makes them more readable and you
   can add some useful comments. Just be careful as spaces are ignored.
+<sup>[[link](#comment-regexes)]</sup>
 
   ```Ruby
   regexp = /
@@ -2747,12 +3120,17 @@ Translations of the guide are available in the following languages:
   /x
   ```
 
-* For complex replacements `sub`/`gsub` can be used with block or hash.
+* <a name="gsub-blocks"></a>
+  For complex replacements `sub`/`gsub` can be used with block or hash.
+<sup>[[link](#gsub-blocks)]</sup>
 
 ## Percent Literals
 
-* Use `%()`(it's a shorthand for `%Q`) for single-line strings which require both
-  interpolation and embedded double-quotes. For multi-line strings, prefer heredocs.
+* <a name="percent-q-shorthand"></a>
+  Use `%()`(it's a shorthand for `%Q`) for single-line strings which require
+  both interpolation and embedded double-quotes. For multi-line strings, prefer
+  heredocs.
+<sup>[[link](#percent-q-shorthand)]</sup>
 
   ```Ruby
   # bad (no interpolation needed)
@@ -2771,10 +3149,11 @@ Translations of the guide are available in the following languages:
   %(<tr><td class="name">#{name}</td>)
   ```
 
-* Avoid `%q` unless you have a string with both `'` and `"` in
-  it. Regular string literals are more readable and should be
-  preferred unless a lot of characters would have to be escaped in
-  them.
+* <a name="percent-q"></a>
+  Avoid `%q` unless you have a string with both `'` and `"` in it. Regular
+  string literals are more readable and should be preferred unless a lot of
+  characters would have to be escaped in them.
+<sup>[[link](#percent-q)]</sup>
 
   ```Ruby
   # bad
@@ -2788,7 +3167,10 @@ Translations of the guide are available in the following languages:
   question = '"What did you say?"'
   ```
 
-* Use `%r` only for regular expressions matching *more than* one '/' character.
+* <a name="percent-r"></a>
+  Use `%r` only for regular expressions matching *more than* one '/'
+  character.
+<sup>[[link](#percent-r)]</sup>
 
   ```Ruby
   # bad
@@ -2802,8 +3184,10 @@ Translations of the guide are available in the following languages:
   %r(^/blog/2011/(.*)$)
   ```
 
-* Avoid the use of `%x` unless you're going to invoke a command with backquotes in
-  it(which is rather unlikely).
+* <a name="percent-x"></a>
+  Avoid the use of `%x` unless you're going to invoke a command with
+  backquotes in it(which is rather unlikely).
+<sup>[[link](#percent-x)]</sup>
 
   ```Ruby
   # bad
@@ -2814,14 +3198,17 @@ Translations of the guide are available in the following languages:
   echo = %x(echo `date`)
   ```
 
-* Avoid the use of `%s`. It seems that the community has decided
-  `:"some string"` is the preferred way to create a symbol with
-  spaces in it.
+* <a name="percent-s"></a>
+  Avoid the use of `%s`. It seems that the community has decided `:"some
+  string"` is the preferred way to create a symbol with spaces in it.
+<sup>[[link](#percent-s)]</sup>
 
-* Prefer `()` as delimiters for all `%` literals, except `%r`. Since
-  braces often appear inside regular expressions in many scenarios a
-  less common character like `{` might be a better choice for a
-  delimiter, depending on the regexp's content.
+* <a name="percent-literal-braces"></a>
+  Prefer `()` as delimiters for all `%` literals, except `%r`. Since braces
+  often appear inside regular expressions in many scenarios a less common
+  character like `{` might be a better choice for a delimiter, depending on the
+  regexp's content.
+<sup>[[link](#percent-literal-braces)]</sup>
 
   ```Ruby
   # bad
@@ -2835,14 +3222,20 @@ Translations of the guide are available in the following languages:
 
 ## Metaprogramming
 
-* Avoid needless metaprogramming.
+* <a name="no-metaprogramming-masturbation"></a>
+  Avoid needless metaprogramming.
+<sup>[[link](#no-metaprogramming-masturbation)]</sup>
 
-* Do not mess around in core classes when writing libraries.
-  (Do not monkey-patch them.)
+* <a name="no-monkey-patching"></a>
+  Do not mess around in core classes when writing libraries.  (Do not
+  monkey-patch them.)
+<sup>[[link](#no-monkey-patching)]</sup>
 
-* The block form of `class_eval` is preferable to the string-interpolated form.
-  - when you use the string-interpolated form, always supply `__FILE__` and `__LINE__`,
-    so that your backtraces make sense:
+* <a name="block-class-eval"></a>
+  The block form of `class_eval` is preferable to the string-interpolated
+  form.  - when you use the string-interpolated form, always supply `__FILE__`
+  and `__LINE__`, so that your backtraces make sense:
+<sup>[[link](#block-class-eval)]</sup>
 
   ```ruby
   class_eval 'def use_relative_model_naming?; true; end', __FILE__, __LINE__
@@ -2850,8 +3243,11 @@ Translations of the guide are available in the following languages:
 
   - `define_method` is preferable to `class_eval{ def ... }`
 
-* When using `class_eval` (or other `eval`) with string interpolation, add a comment block
-  showing its appearance if interpolated (a practice used in Rails code):
+* <a name="eval-comment-docs"></a>
+  When using `class_eval` (or other `eval`) with string interpolation, add a
+  comment block showing its appearance if interpolated (a practice used in Rails
+  code):
+<sup>[[link](#eval-comment-docs)]</sup>
 
   ```ruby
   # from activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -2871,10 +3267,13 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* Avoid using `method_missing` for metaprogramming because backtraces become messy,
-  the behavior is not listed in `#methods`, and misspelled method calls might silently
-  work, e.g. `nukes.launch_state = false`. Consider using delegation, proxy, or
-  `define_method` instead. If you must use `method_missing`:
+* <a name="no-method-missing"></a>
+  Avoid using `method_missing` for metaprogramming because backtraces become
+  messy, the behavior is not listed in `#methods`, and misspelled method calls
+  might silently work, e.g. `nukes.launch_state = false`. Consider using
+  delegation, proxy, or `define_method` instead. If you must use
+  `method_missing`:
+<sup>[[link](#no-method-missing)]</sup>
 
   - Be sure to [also define `respond_to_missing?`](http://blog.marc-andre.ca/2010/11/methodmissing-politely.html)
   - Only catch methods with a well-defined prefix, such as `find_by_*` -- make your code as assertive as possible.
@@ -2905,19 +3304,32 @@ Translations of the guide are available in the following languages:
 
 ## Misc
 
-* Write `ruby -w` safe code.
+* <a name="always-warn"></a>
+  Write `ruby -w` safe code.
+<sup>[[link](#always-warn)]</sup>
 
-* Avoid hashes as optional parameters. Does the method do too much? (Object initializers are exceptions for this rule).
+* <a name="no-optional-hash-params"></a>
+  Avoid hashes as optional parameters. Does the method do too much? (Object
+  initializers are exceptions for this rule).
+<sup>[[link](#no-optional-hash-params)]</sup>
 
-* Avoid methods longer than 10 LOC (lines of code). Ideally, most methods will be shorter than
-  5 LOC. Empty lines do not contribute to the relevant LOC.
+* <a name="short-methods"></a>
+  Avoid methods longer than 10 LOC (lines of code). Ideally, most methods will
+  be shorter than 5 LOC. Empty lines do not contribute to the relevant LOC.
+<sup>[[link](#short-methods)]</sup>
 
-* Avoid parameter lists longer than three or four parameters.
+* <a name="too-many-params"></a>
+  Avoid parameter lists longer than three or four parameters.
+<sup>[[link](#too-many-params)]</sup>
 
-* If you really need "global" methods, add them to Kernel
-  and make them private.
+* <a name="private-global-methods"></a>
+  If you really need "global" methods, add them to Kernel and make them
+  private.
+<sup>[[link](#private-global-methods)]</sup>
 
-* Use module instance variables instead of global variables.
+* <a name="instance-vars"></a>
+  Use module instance variables instead of global variables.
+<sup>[[link](#instance-vars)]</sup>
 
   ```Ruby
   # bad
@@ -2933,22 +3345,38 @@ Translations of the guide are available in the following languages:
   Foo.bar = 1
   ```
 
-* Avoid `alias` when `alias_method` will do.
+* <a name="alias-method"></a>
+  Avoid `alias` when `alias_method` will do.
+<sup>[[link](#alias-method)]</sup>
 
-* Use `OptionParser` for parsing complex command line options and
-`ruby -s` for trivial command line options.
+* <a name="optionparser"></a>
+  Use `OptionParser` for parsing complex command line options and `ruby -s`
+  for trivial command line options.
+<sup>[[link](#optionparser)]</sup>
 
-* Prefer `Time.now` over `Time.new` when retrieving the current system time.
+* <a name="time-now"></a>
+  Prefer `Time.now` over `Time.new` when retrieving the current system time.
+<sup>[[link](#time-now)]</sup>
 
-* Code in a functional way, avoiding mutation when that makes sense.
+* <a name="functional-code"></a>
+  Code in a functional way, avoiding mutation when that makes sense.
+<sup>[[link](#functional-code)]</sup>
 
-* Do not mutate arguments unless that is the purpose of the method.
+* <a name="no-arg-mutations"></a>
+  Do not mutate arguments unless that is the purpose of the method.
+<sup>[[link](#no-arg-mutations)]</sup>
 
-* Avoid more than three levels of block nesting.
+* <a name="three-is-the-number-thou-shalt-count"></a>
+  Avoid more than three levels of block nesting.
+<sup>[[link](#three-is-the-number-thou-shalt-count)]</sup>
 
-* Be consistent. In an ideal world, be consistent with these guidelines.
+* <a name="be-consistent"></a>
+  Be consistent. In an ideal world, be consistent with these guidelines.
+<sup>[[link](#be-consistent)]</sup>
 
-* Use common sense.
+* <a name="common-sense"></a>
+  Use common sense.
+<sup>[[link](#common-sense)]</sup>
 
 ## Tools
 


### PR DESCRIPTION
Every bullet is anchored with a short `<a name>` tag and includes a superscript `link` anchor at the end. This makes life easier for me when I want to refer people to a particular guideline, such as:

https://github.com/rapid7/ruby-style-guide/blob/add-anchors/README.md#no-and-or-or

When dealing with new Rubyists and their contributions to my project, I want to drop them exactly on what rule I'm talking about when they don't know about the Ruby Style Guide, instead of telling them to scroll around or ctrl-F or anything like that.

This PR implements many of the suggestions in #319.
