### PR TITLE
Switch stance on line-based coding style

### DIFF
--- a/README.md
+++ b/README.md
@@ -2267,11 +2267,11 @@ this rule only to arrays with two or more elements.
     STATES = %i(draft open closed)
     ```
 
-* Avoid comma after the last item of an `Array` or `Hash` literal, especially
-  when the items are not on separate lines.
+* Prefer adding a comma after the last item of an `Array` or `Hash` literal, 
+  but only when the items are on separate lines.
 
     ```Ruby
-    # bad - easier to move/add/remove items, but still not preferred
+    # good - easier to move/add/remove items, does not change adjacent lines
     VALUES = [
                1001,
                2020,


### PR DESCRIPTION
This change will help to minimize the number of changes to adjacent lines, which will allow for more productive use of tools like `git blame`.

By preferring a trailing comma on the end of the last item in of an `Array` or `Hash` literal, changes will be restricted to a single line because each future line will be syntactically complete. To be better explain, consider a Hash with 2 keys:

``` ruby
{
  foo: 'bar',
  baz: 'qux'
}
```

In order to add another key/value pair to this Hash, we would have to change 2 lines:

``` ruby
{
  foo: 'bar',
  baz: 'qux',
  quux: 'corge'
}
```

Specifically, we must add a comma to the previous key/value pair and then add the key/value pair--changes on two lines.

With this proposed change in place, the above Hash would instead be declared like so:

``` ruby
{
  foo: 'bar',
  baz: 'qux',
}
```

Which would simplify the effort needed to incorporate another key/value pair anywhere in the Hash. Now, to add the same key/value pair to the Hash, we only need to modify one line:

``` ruby
{
  foo: 'bar',
  baz: 'quz',
  quux: 'corge',
}
```

Further reading:
- http://mislav.uniqpath.com/2014/02/hidden-documentation/
- https://gist.github.com/isaacs/357981#comment-397
