### PR TITLE
Avoid non nil checks in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -2649,7 +2649,7 @@ Translations of the guide are available in the following languages:
   rescue
     # .. handle error
   ensure
-    f.close unless f.nil?
+    f.close if f
   end
   ```
 


### PR DESCRIPTION
`f = File.open('testfile')` is not boolean, so avoid non-`nil` checks. Also keep line length to 80.
