### PR TITLE
Fix reference to "braces" where "parentheses" was meant.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3201,7 +3201,7 @@ Translations of the guide are available in the following languages:
 <sup>[[link](#percent-s)]</sup>
 
 * <a name="percent-literal-braces"></a>
-  Prefer `()` as delimiters for all `%` literals, except `%r`. Since braces
+  Prefer `()` as delimiters for all `%` literals, except `%r`. Since parentheses
   often appear inside regular expressions in many scenarios a less common
   character like `{` might be a better choice for a delimiter, depending on the
   regexp's content.


### PR DESCRIPTION
The text refers to "braces", but it doesn't make any sense unless the word "parentheses" is used instead. Change the text so it says something logical.
