### PR TITLE
note safe assignment exception to no parens around condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -929,6 +929,9 @@ Translations of the guide are available in the following languages:
   end
   ```
 
+Note that there is an exception to this rule, namely [safe assignment in
+condition](#safe-assignment-in-condition).
+
 * <a name="no-multiline-while-do"></a>
   Never use `while/until condition do` for multi-line `while/until`.
 <sup>[[link](#no-multiline-while-do)]</sup>


### PR DESCRIPTION
I was confused about the rule of not using parentheses around conditions, since it seemed to conflict with the safe assignment in condition rule.  Since the safe assignment rule is an exception to the first rule, I'm suggesting an explicit note to that effect.
