### PR TITLE
fix 'bad' example for '&&='

### DIFF
--- a/README.md
+++ b/README.md
@@ -1311,7 +1311,7 @@ Translations of the guide are available in the following languages:
   end
 
   # bad
-  something = something ? nil : something.downcase
+  something = something ? something.downcase : nil
 
   # ok
   something = something.downcase if something


### PR DESCRIPTION
Previous version of 'bad' example is wrong, meaningless and even can lead to error 'NoMethodError'
