### PR TITLE
hash-fetch-defaults: fetch(:is_evil, true) to fetch(:is_evil) { true }

### DIFF
--- a/README.md
+++ b/README.md
@@ -2830,7 +2830,7 @@ Translations of the guide are available in the following languages:
   batman[:is_evil] || true # => true
 
   # good - fetch work correctly with falsy values
-  batman.fetch(:is_evil, true) # => false
+  batman.fetch(:is_evil) { true } # => false
   ```
 
 * <a name="use-hash-blocks"></a>


### PR DESCRIPTION
In [hash-fetch-defaults](https://github.com/bbatsov/ruby-style-guide#hash-fetch-defaults), the last line is `batman.fetch(:is_evil, true)`. This contradicts the next guideline of preferring the use of a block. 

change `batman.fetch(:is_evil, true)` to `batman.fetch(:is_evil) { true }`
