### PR TITLE
Made string quotes consistent for the when example

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Translations of the guide are available in the following languages:
     when song.duration > 120
       puts 'Too long!'
     when Time.now.hour > 21
-      puts "It's too late"
+      puts 'It's too late'
     else
       song.play
   end
@@ -319,7 +319,7 @@ Translations of the guide are available in the following languages:
   when song.duration > 120
     puts 'Too long!'
   when Time.now.hour > 21
-    puts "It's too late"
+    puts 'It's too late'
   else
     song.play
   end


### PR DESCRIPTION
The `when` example used mixed string quotes (some strings with single quotes, some with double quotes), without any real cause for the double quoted string (no string interpolation needed or expected on). All of them are now single quotes for consistency.
