### PR TITLE
Multi-line method chaining style.

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,28 +457,11 @@ Translations of the guide are available in the following languages:
   ```
 
 * <a name="consistent-multi-line-chains"></a>
-    Adopt a consistent multi-line method chaining style. There are two
-    popular styles in the Ruby community, both of which are considered
-    good - leading `.` (Option A) and trailing `.` (Option B).
+  When continuing a chained method invocation on another line,
+  include the `.` on the first line to indicate that the
+  expression continues.
 <sup>[[link](#consistent-multi-line-chains)]</sup>
-
-  * **(Option A)** When continuing a chained method invocation on
-    another line keep the `.` on the second line.
-
-    ```Ruby
-    # bad - need to consult first line to understand second line
-    one.two.three.
-      four
-
-    # good - it's immediately clear what's going on the second line
-    one.two.three
-      .four
-    ```
-
-  * **(Option B)** When continuing a chained method invocation on another line,
-    include the `.` on the first line to indicate that the
-    expression continues.
-
+ 
     ```Ruby
     # bad - need to read ahead to the second line to know that the chain continues
     one.two.three


### PR DESCRIPTION
We picked Option B because:
- reasons stated originally in style guide
- allows copy paste into a REPL

Left link to discussion for reference
