### PR TITLE
fix unintended difference

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Translations of the guide are available in the following languages:
     ```Ruby
     # bad
     1 .. 3
-    'a' ... 'z'
+    'a' .. 'z'
 
     # good
     1..3


### PR DESCRIPTION
.. vs ... in paragraph about spaces

bad example was:
`'a' ... 'z'`
good example was:
`'a'..'z'`

I changed first to two periods, changing second to three also would be OK.
