### PR TITLE
Change to implicit begin block

### DIFF
--- a/README.md
+++ b/README.md
@@ -2500,11 +2500,9 @@ condition](#safe-assignment-in-condition).
 
   ```Ruby
   def foo
-    begin
-      fail
-    ensure
-      return 'very bad idea'
-    end
+    fail
+  ensure
+    return 'very bad idea'
   end
   ```
 


### PR DESCRIPTION
One chapter after the `Do not return from an ensure block`, is written that i should use `implicit begin blocks`.
So why this isn't one?
