### PR TITLE
keyword arguments for boolean arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,30 @@ Translations of the guide are available in the following languages:
   some_method('w', 'x', 'y', 'z') # => 'w, x, y, z'
   ```
 
+* <a name="keyword_arguments"></a>
+  Use keyword arguments or options hash when passing boolean argument to a method.
+
+  ```Ruby
+  # bad
+  def some_method(bar = false)
+    puts bar
+  end
+
+  # good (ruby <= 1.9.x)
+  def some_method(options = {})
+    bar = options.fetch(:bar, false)
+    puts bar
+  end
+
+  # good (ruby >= 2.0)
+  def some_method(bar: false)
+    puts bar
+  end
+
+  some_method            # => false
+  some_method(bar: true) # => true
+  ```
+
 * <a name="parallel-assignment"></a>
     Avoid the use of parallel assignment for defining variables. Parallel
     assignment is allowed when it is the return of a method call, used with


### PR DESCRIPTION
I found that i often see methods which consume a boolean argument and depends on it method define some logic. However i every time have to check the source because ...

some dummy example

``` Ruby
def load_posts(include_unpublished = false)
  if include_unpublished?
    MyDataStorage.load_all
  else
    MyDataStorage.published
  end
end

# in code method invoked as
1) load_posts(false) 
2) load_posts
3) load_posts(true)
# and it is not meaningful for me

# however if we define method like => def load_posts(include_unpublished: false)
4) load_posts(include_unpublished: true)
# now i know what will happen without reading source code of method
```

---

i also have the same thoughts about numbers as arguments, and keyword arguments is a nice thing to use. 
