### PR TITLE
comma for last element in multi line Array or Hash is valid - from point of source control 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3134,12 +3134,23 @@ resource cleanup when possible.
   ```
 
 * <a name="no-trailing-array-commas"></a>
-  Avoid comma after the last item of an `Array` or `Hash` literal, especially
-  when the items are not on separate lines.
+  Use of comma after the last item of an `Array` or `Hash` literal is 
+  acceptable when you are dealing with items on multiple lines, as
+  it prevents source controls versioning (e.g. Git) to point to multiple
+  lines when you introduce a change.
+  
+  Avoid comma after the last item when the items are not on separate lines.
 <sup>[[link](#no-trailing-array-commas)]</sup>
 
   ```Ruby
-  # bad - easier to move/add/remove items, but still not preferred
+  # good - it's clean
+  VALUES = [
+             1001,
+             2020,
+             3333
+           ]
+           
+  # good - if you introduce new item, only one line is marked as changed is Git
   VALUES = [
              1001,
              2020,


### PR DESCRIPTION
The reasoning for this was originally that "because it's easier to add elements" which I agree is not good point on it's own -> [discussion](https://github.com/bbatsov/ruby-style-guide/issues/76).

But there is far bigger point missed from perspective of version source control (like in Git) in a sense that one line change requires another line to be marked as changed in source control

So if you have 

```
{
  foo: 'foo'
}
```

....and you introduce `bar: :bar`

```
{
  foo: 'foo',
  bar: :bar
}
```

the source control will mark both lines as changed as you introduced a comma

```git
    {
+     foo: 'foo',
+     bar: :bar
    }
```

Where as you have that line with comma from beginning:


```
{
  foo: 'foo',
}
```

... and you introduce new element on  a new line

```
{
  foo: 'foo',
  bar: :bar,
}
```

source control will show that only one line has changed:


```git
    {
      foo: 'foo',
+     bar: :bar,
    }
```

And this is far bigger argument than cleanliness