### PR TITLE
Regexp#===, String#match? consistent behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -1614,7 +1614,7 @@ condition](#safe-assignment-in-condition).
   # good
   something.is_a?(Array)
   (1..100).include?(7)
-  some_string =~ /something/
+  some_string.match?(/something/)
   ```
 
 * <a name="eql"></a>


### PR DESCRIPTION
For consistent return values, favor `String#match?` (returns boolean)
over `String#=~` (returns integer or nil) when replacing `Regexp#===`
(also returns boolean).