### PR TITLE
Consistent use of accessor in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -2705,7 +2705,7 @@ no parameters.
     end
 
     def to_s
-      "#{@first_name} #{@last_name}"
+      "#{first_name} #{last_name}"
     end
   end
   ```


### PR DESCRIPTION
The style guide implies that inside your class you should use the accessor methods `attr_reader` creates and not the ivars directly. Issue #538 questioned if this should be the other way around, but it appears not.

This PR changes the `def to_s` example to not use the ivar directly in accordance.
