### PR TITLE
fix readme according to cops from other module

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,13 +494,11 @@ Translations of the guide are available in the following languages:
   # good
   class Foo
     def foo
-      begin
-        do_something do
-          something
-        end
-      rescue
+      do_something do
         something
       end
+    rescue
+      something
     end
   end
   ```


### PR DESCRIPTION
Hey.
You have a cop which says do not use begin blocks for rescues wherever it possible.
[link](https://github.com/bbatsov/ruby-style-guide#begin-implicit)
So now this example after my editing will follow both rules 
`Style/RedundantBegin` <br> `Layout/EmptyLinesAroundExceptionHandlingKeywords`