### PR TITLE
Add historical reference to indent-when-to-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,10 @@ Translations of the guide are available in the following languages:
 
 * <a name="indent-when-to-case"></a>
   Indent `when` as deep as `case`. This is the style established in both
-  "The Ruby Programming Language" and "Programming Ruby".
+  "The Ruby Programming Language" and "Programming Ruby". Historically it
+  is derived from the fact that `case` and `switch` statements are not blocks,
+  hence should not be indented, and the `when` and `else` keywords are labels 
+  (compiled in the C language, they are litterally labels for `JMP` calls).
 <sup>[[link](#indent-when-to-case)]</sup>
 
   ```ruby


### PR DESCRIPTION
Justifying `indent-when-to-case` by referencing early literature feels a little weak. The history goes way back to at least the C language.

There's an excellent discussion on https://stackoverflow.com/questions/4509039/why-the-strange-indentation-on-switch-statements