### PR TITLE
Fix Unescaped Menu Item

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,18 +647,18 @@ Translations of the guide are available in the following languages:
   ```ruby
   # bad - single indent
   menu_item = %w[Spam Spam Spam Spam Spam Spam Spam Spam
-    Baked beans Spam Spam Spam Spam Spam]
+    Baked\ beans Spam Spam Spam Spam Spam]
 
   # good
   menu_item = %w[
     Spam Spam Spam Spam Spam Spam Spam Spam
-    Baked beans Spam Spam Spam Spam Spam
+    Baked\ beans Spam Spam Spam Spam Spam
   ]
 
   # good
   menu_item =
     %w[Spam Spam Spam Spam Spam Spam Spam Spam
-     Baked beans Spam Spam Spam Spam Spam]
+     Baked\ beans Spam Spam Spam Spam Spam]
   ```
 
 * <a name="underscores-in-numerics"></a>


### PR DESCRIPTION
Initiating the array like so will split `Baked Beans` as two array items:
```
2.2.9 :010 > menu_item =
2.2.9 :011 >     %w[Spam Spam Spam Spam Spam Spam Spam Spam
2.2.9 :012]>    Baked beans Spam Spam Spam Spam Spam]
 => ["Spam", "Spam", "Spam", "Spam", "Spam", "Spam", "Spam", "Spam", "Baked", "beans", "Spam", "Spam", "Spam", "Spam", "Spam"]
```

This commit fixes this.