### PR TITLE
Add rationale-comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2486,6 +2486,31 @@ condition](#safe-assignment-in-condition).
     Write self-documenting code and ignore the rest of this section. Seriously!
     <sup>[[link](#no-comments)]</sup>
 
+  * <a name="rationale-comments"></a>
+    If the *how* can be made self-documenting, but not the *why* (e.g., the
+    code works around non-obvious library behavior, or implements an algorithm from
+    an academic paper), add a comment explaining the rationale behind the code.
+
+    ```ruby
+    # bad
+
+    x = BuggyClass.something.dup
+
+    def compute_dependency_graph
+      ...30 lines of recursive graph merging...
+    end
+
+    # good
+
+    # BuggyClass returns an internal object, so we have to dup it to modify it.
+    x = BuggyClass.something.dup
+
+    # This is algorithm 6.4(a) from Worf & Yar's _Amazing Graph Algorithms_ (2243).
+    def compute_dependency_graph
+      ...30 lines of recursive graph merging...
+    end
+    ```
+
   * <a name="english-comments"></a>
     Write comments in English.
     <sup>[[link](#english-comments)]</sup>


### PR DESCRIPTION
Mention a reason "self-documenting code" isn't always possible.