### PR TITLE
Fixed a small styling problem at the "Syntax" chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,7 +853,7 @@ Translations of the guide are available in the following languages:
 
           # body omitted
         end
-      ```
+        ```
 
     Can omit parentheses for
 


### PR DESCRIPTION
The indentation of the code snippet before "Can omit parentheses for" was wrong which made that whole part look like a code snippet. This fixes the styling again.