### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2199,10 +2199,10 @@ condition](#safe-assignment-in-condition).
 
     ```ruby
     # bad - identifier using non-ascii characters
-    заплата = 1_000
+    зарплата = 1_000
 
     # bad - identifier is a Bulgarian word, written with Latin letters (instead of Cyrillic)
-    zaplata = 1_000
+    zarplata = 1_000
 
     # good
     salary = 1_000


### PR DESCRIPTION
Salary in russian (as non-ascii example) will be зарплата (zarplata), not заплата (zaplata)