### PR TITLE
1903/no jira adjust multiline method call indentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Rubocop
+.rubocop.yml   @alecjacobs5401 @peterwilson
+.hound.yml     @alecjacobs5401

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,11 @@
+ruby:
+  config_file: .rubocop.yml
+
+# We use jshint in grunt commands, so ignore it here
+jshint:
+  enabled: false
+
+scss:
+  config_file: .scss-lint.yml
+
+fail_on_violations: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,115 @@
+# Examples of how to specifically exclude certain things
+AllCops:
+  TargetRubyVersion: 2.1.9
+  Exclude:
+    - '**/*.yml'
+    - '**/*.sql'
+    - 'config/**/*'
+    - 'vendor/bundle/**/*'
+    - 'vendor/gems/**/*'
+    - 'node_modules/**/*'
+    - 'db/migrate/**/*.rb'
+    - !ruby/regexp /old_and_unused\.rb$/
+
+# Configure cops for styles that we do not adhere to or are not agreed upon
+# Default settings and options can be viewed here: https://raw.githubusercontent.com/bbatsov/rubocop/master/config/default.yml
+# Please add new configurations in alphabetical order
+
+Layout/AccessModifierIndentation:
+  IndentationWidth: 2
+
+Layout/EmptyLinesAroundClassBody:
+  Enabled: false
+
+Layout/EndOfLine:
+  Enabled: false
+
+Layout/ExtraSpacing:
+  Enabled: false
+
+Layout/IndentHeredoc:
+  EnforcedStyle: unindent
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: false
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - 'Rakefile'
+    - '**/*.rake'
+    - 'test/**/*_test.rb'
+    # Autobahn - RSpec relies on large blocks
+    - 'tests/**/*_spec.rb'
+    - 'spec/**/*_spec.rb'
+
+Metrics/ClassLength:
+  Exclude:
+    - 'test/**/*_test.rb'
+
+Metrics/LineLength:
+  Max: 150
+
+Style/AndOr:
+  EnforcedStyle: conditionals
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+# Mapping of methods to prefer, alternate => preferred
+Style/CollectionMethods:
+  Enabled: true
+  PreferredMethods:
+    collect: 'map'
+    collect!: 'map!'
+    inject: 'reduce'
+    detect: 'find'
+    find_all: 'select'
+    length: 'size'
+
+Style/CommentedKeyword:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/DoubleNegation:
+  Enabled: false
+
+Style/EachWithObject:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/HashSyntax:
+  EnforcedStyle: ruby19_no_mixed_keys
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/PreferredHashMethods:
+  Enabled: false
+
+Style/RegexpLiteral:
+  Enabled: false
+
+Style/RescueStandardError:
+  Enabled: false
+
+Layout/SpaceInsideBlockBraces:
+  EnforcedStyleForEmptyBraces: space
+
+Style/SignalException:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: false
+
+Style/SymbolArray:
+  Enabled: false
+
+Style/WordArray:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,9 @@ Layout/ExtraSpacing:
 Layout/IndentHeredoc:
   EnforcedStyle: unindent
 
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented_relative_to_receiver
+
 Layout/SpaceBeforeFirstArg:
   Enabled: false
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Prelude
 Invoca Ruby Style Guide initially forked from https://github.com/bbatsov/ruby-style-guide.
 
+The contents of this styleguide are to be enforced by (rubocop)[https://github.com/bbatsov/rubocop]
+and automated in the code review process by (HoundCI)[https://houndci.com/]
+
+Any adjustments to this styleguide should be captured in the `.rubocop.yml` config.
+
 ## Table of Contents
 
 * [Source Code Layout](#source-code-layout)

--- a/README.md
+++ b/README.md
@@ -572,21 +572,24 @@ hash = { :one => 1, :two => 2 }
 hash = { one: 1, two: 2 }
 ```
 
-### `lambda` is preferred over `proc`/`Proc.new`.
+### `->` / `lambda` are preferred over `proc`/`Proc.new`.
 This is because `lambda`s enforce argument list cardinality and have unsurprising `return` semantics.
 (Only use `proc` if you really need a return statement that returns from the enclosing code.)
 More details [here](http://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Method_Calls#Understanding_blocks.2C_Procs_and_methods).
 
-### Ruby 1.9 `lambda` literal syntax is preferred.
+### Ruby 1.9 `->` (stabby lambda) syntax is preferred when there are arguments, since stabby lambda arguments are treated just like regular method arguments. For example, these special arguments work for stabby lambda but not `lambda` or `Proc.new`:
+* default arguments
+* keyword arguments
+* block (`&`) argument
 
 ```ruby
 # bad
-lam = lambda { |a, b| a + b }
+lam = lambda { |a, b| a + (b || 0) }
 lam.call(1, 2)
 
 # good
-lambda = ->(a, b) { a + b }
-lambda.(1, 2)
+lambda = ->(a, b = 0) { a + b }
+lambda.call(1, 2)
 ```
 
 ### Use `_` for unused block parameters.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ beneficial to each and every Ruby developer out there.
 
 By the way, if you're into Rails you might want to check out the
 complementary
-[Ruby on Rails 3 Style Guide](https://github.com/bbatsov/rails-style-guide).
+[Ruby on Rails 3 Style Guide](https://github.com/RingRevenue/rails-style-guide).
 
 # The Ruby Style Guide
 

--- a/README.md
+++ b/README.md
@@ -898,12 +898,6 @@ email_with_name = user.name + ' <' + user.email + '>'
 email_with_name = "#{user.name} <#{user.email}>"
 ```
 
-### Consider padding string interpolation code with space. It more clearly sets the code apart from the string.
-
-```ruby
-"#{ user.last_name }, #{ user.first_name }"
-```
-
 ### `String#<<` performs better by mutating the string in place.
 `String#+`, avoids mutation (which is good in a functional way) but therefore runs slower since it creates a new string object.
 

--- a/README.md
+++ b/README.md
@@ -21,44 +21,44 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 ### Use two **spaces** per indentation level. No hard tabs.  
 
 ```ruby
-    # good
-    def some_method
-      do_something
-    end
+# good
+def some_method
+  do_something
+end
 
-    # bad - four spaces
-    def some_method
-        do_something
-    end
+# bad - four spaces
+def some_method
+    do_something
+end
 ```
 
 ### Use spaces around operators and `=>`, after commas, colons and semicolons, around `{`
   and before `}`.  (But there is no need for spaces inside the empty hash `{}`.)
 
 ```ruby
-    a, b = 1, 2 + 3
-    location = { :city => 'Santa Barbara', :state => 'CA' }
-    size > 10 ? 'large' : 'small'
-    [1, 2, 3].each { |e| puts e }
-    params = {}
+a, b = 1, 2 + 3
+location = { :city => 'Santa Barbara', :state => 'CA' }
+size > 10 ? 'large' : 'small'
+[1, 2, 3].each { |e| puts e }
+params = {}
 ```
 
-    The only exception is when using the exponent operator:
+The only exception is when using the exponent operator:
 
 ```ruby
-    # bad
-    e = M * c ** 2
+# bad
+e = M * c ** 2
 
-    # good
-    e = M * c**2
+# good
+e = M * c**2
 ```
 
 ### No spaces after `(`, `[` or before `]`, `)`.
 
 ```ruby
-    some(arg).other
-    [1, 2, 3].length
-    collection = []
+some(arg).other
+[1, 2, 3].length
+collection = []
 ```
 
 ### Indent `when` as deep as `case`. I know that many would disagree
@@ -66,77 +66,77 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
   Programming Language" and "Programming Ruby".
 
 ```ruby
-    case
-    when song.name == 'Misty'
-      puts 'Not again!'
-    when song.duration > 120
-      puts 'Too long!'
-    when Time.now.hour > 21
-      puts "It's too late"
-    else
-      song.play
-    end
+case
+when song.name == 'Misty'
+  puts 'Not again!'
+when song.duration > 120
+  puts 'Too long!'
+when Time.now.hour > 21
+  puts "It's too late"
+else
+  song.play
+end
 
-    kind = case year
-           when 1850..1889 then 'Blues'
-           when 1890..1909 then 'Ragtime'
-           when 1910..1929 then 'New Orleans Jazz'
-           when 1930..1939 then 'Swing'
-           when 1940..1950 then 'Bebop'
-           else 'Jazz'
-           end
+kind = case year
+       when 1850..1889 then 'Blues'
+       when 1890..1909 then 'Ragtime'
+       when 1910..1929 then 'New Orleans Jazz'
+       when 1930..1939 then 'Swing'
+       when 1940..1950 then 'Bebop'
+       else 'Jazz'
+       end
 ```
 
 ### Use empty lines between `def`s and to break up a method into logical
   paragraphs.
 
 ```ruby
-    def some_method
-      data = initialize(options)
+def some_method
+  data = initialize(options)
 
-      data.manipulate!
+  data.manipulate!
 
-      data.result
-    end
+  data.result
+end
 
-    def some_method
-      result
-    end
+def some_method
+  result
+end
 ```
 
 ### Align the parameters of a method call if they span over multiple lines using normal indent.
 
 ```ruby
-    # starting point (line is too long)
-    def send_mail(source)
-      Mailer.deliver(to: 'bob@example.com', from: 'us@example.com', subject: 'Important message', body: source.text)
-    end
+# starting point (line is too long)
+def send_mail(source)
+  Mailer.deliver(to: 'bob@example.com', from: 'us@example.com', subject: 'Important message', body: source.text)
+end
 
-    # good (normal indent)
-    def send_mail(source)
-      Mailer.deliver(
-        to: 'bob@example.com',
-        from: 'us@example.com',
-        subject: 'Important message',
-        body: source.text)
-    end
+# good (normal indent)
+def send_mail(source)
+  Mailer.deliver(
+    to: 'bob@example.com',
+    from: 'us@example.com',
+    subject: 'Important message',
+    body: source.text)
+end
 
-    # bad (double indent)
-    def send_mail(source)
-      Mailer.deliver(
-          to: 'bob@example.com',
-          from: 'us@example.com',
-          subject: 'Important message',
-          body: source.text)
-    end
+# bad (double indent)
+def send_mail(source)
+  Mailer.deliver(
+      to: 'bob@example.com',
+      from: 'us@example.com',
+      subject: 'Important message',
+      body: source.text)
+end
 
-    # bad
-    def send_mail(source)
-      Mailer.deliver(to: 'bob@example.com',
-                     from: 'us@example.com',
-                     subject: 'Important message',
-                     body: source.text)
-    end
+# bad
+def send_mail(source)
+  Mailer.deliver(to: 'bob@example.com',
+                 from: 'us@example.com',
+                 subject: 'Important message',
+                 body: source.text)
+end
 ```
 
 ### Use RDoc and its conventions for API documentation.  Don't put an
@@ -151,13 +151,13 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
   parentheses when the method doesn't accept any arguments.
 
  ```ruby
-     def some_method
-       ...
-     end
+def some_method
+  ...
+end
 
-     def some_method_with_arguments(arg1, arg2)
-       ...
-     end
+def some_method_with_arguments(arg1, arg2)
+  ...
+end
  ```
 
 ### Never use `for`, unless you know exactly why. Most of the time iterators
@@ -167,29 +167,29 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
   in its block will be visible outside it.
 
 ```ruby
-    arr = [1, 2, 3]
+arr = [1, 2, 3]
 
-    # bad
-    for elem in arr do
-      puts elem
-    end
+# bad
+for elem in arr do
+  puts elem
+end
 
-    # good
-    arr.each { |elem| puts elem }
+# good
+arr.each { |elem| puts elem }
 ```
 
 ### Never use `then` for multi-line `if/unless`.
 
 ```ruby
-    # bad
-    if some_condition then
-      ...
-    end
+# bad
+if some_condition then
+  ...
+end
 
-    # good
-    if some_condition
-      ...
-    end
+# good
+if some_condition
+  ...
+end
 ```
 
 ### Use one expression per branch in a ternary operator. This
@@ -198,26 +198,26 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
   Avoid multi-line ternary; use `if/unless` instead.
 
 ```ruby
-    # bad
-    some_condition ? (nested_condition ? nested_something : nested_something_else) : something_else
+# bad
+some_condition ? (nested_condition ? nested_something : nested_something_else) : something_else
 
-    # good
-    if some_condition
-      nested_condition ? nested_something : nested_something_else
-    else
-      something_else
-    end
+# good
+if some_condition
+  nested_condition ? nested_something : nested_something_else
+else
+  something_else
+end
 ```
 
 ### Never use `if x: ...` - it is removed in Ruby 1.9. Use multi-line if or
   the ternary operator instead.
 
 ```ruby
-    # bad
-    result = if some_condition: something else something_else end
+# bad
+result = if some_condition: something else something_else end
 
-    # good
-    result = some_condition ? something : something_else
+# good
+result = some_condition ? something : something_else
 ```
 
 ### Use `when x then ...` for one-line cases. The alternative syntax
@@ -226,23 +226,23 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 ### Use `&&/||` for boolean expressions, `and/or` for control flow.
 
 ```ruby
-    # boolean expression
-    if document.text_changed? || document.settings_changed?
-      document.save!
-    end
+# boolean expression
+if document.text_changed? || document.settings_changed?
+  document.save!
+end
 
-    # control flow
-    document.saved? or document.save!
+# control flow
+document.saved? or document.save!
 ```
 
   Beware: `and/or` have lower precedence than `=`!
-  
+
 ```ruby
-    flag = top_of_page? or reset_page
-    
-    # is equivalent to
-    (flag = top_of_page?) or reset_page
-    
+flag = top_of_page? or reset_page
+
+# is equivalent to
+(flag = top_of_page?) or reset_page
+
 ```
 
 ### Only use trailing `if/unless` when they are rare footnotes that can be
@@ -251,49 +251,49 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
   (A good alternative for assertions and other one-line code that rarely executes is control-flow `and/or`.)
 
 ```ruby
-    # bad -- the raise rarely executes
-    raise ArgumentError, "name must be provided" unless name.present?
+# bad -- the raise rarely executes
+raise ArgumentError, "name must be provided" unless name.present?
 
-    # good
-    name.present? or raise ArgumentError, "name must be provided" 
+# good
+name.present? or raise ArgumentError, "name must be provided"
 
-    # good -- the unless is a rare footnote
-    formt(page) unless page.already_formatted?
-    
-    # good -- the if is almost always true
-    send_notification(users) if users.any?
+# good -- the unless is a rare footnote
+formt(page) unless page.already_formatted?
+
+# good -- the if is almost always true
+send_notification(users) if users.any?
 ```
 
 ### Favor `unless` over `if` for negative conditions (or use control
   flow `or`).
 
 ```ruby
-    # bad
-    do_something if !some_condition
+# bad
+do_something if !some_condition
 
-    # good
-    do_something unless some_condition
+# good
+do_something unless some_condition
 
-    # another good option
-    some_condition or do_something
+# another good option
+some_condition or do_something
 ```
 
 ### Never use `unless` with `else`. Rewrite these with the positive case first.
 
 ```ruby
-    # bad
-    unless success?
-      puts 'failure'
-    else
-      puts 'success'
-    end
+# bad
+unless success?
+  puts 'failure'
+else
+  puts 'success'
+end
 
-    # good
-    if success?
-      puts 'success'
-    else
-      puts 'failure'
-    end
+# good
+if success?
+  puts 'success'
+else
+  puts 'failure'
+end
 ```
 
 ### Don't use parentheses around the condition of an `if/unless/while`,
@@ -301,43 +301,43 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
   value of `=`" below).
 
 ```ruby
-    # bad
-    if (x > 10)
-      ...
-    end
+# bad
+if (x > 10)
+  ...
+end
 
-    # good
-    if x > 10
-      ...
-    end
+# good
+if x > 10
+  ...
+end
 
-    # ok
-    if (x = self.next_value)
-      ...
-    end
+# ok
+if (x = self.next_value)
+  ...
+end
 ```
 
 ### Favor modifier `while/until` usage when you have a single-line
   body.
 
 ```ruby
-    # bad
-    while some_condition
-      do_something
-    end
+# bad
+while some_condition
+  do_something
+end
 
-    # good
-    do_something while some_condition
+# good
+do_something while some_condition
 ```
 
 ### Favor `until` over `while` for negative conditions.
 
 ```ruby
-    # bad
-    do_something while !some_condition
+# bad
+do_something while !some_condition
 
-    # good
-    do_something until some_condition
+# good
+do_something until some_condition
 ```
 
 ### Omit parentheses around parameters for methods that are part of an
@@ -347,19 +347,19 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
   method invocations.
 
 ```ruby
-    class Person
-      attr_reader :name, :age
+class Person
+  attr_reader :name, :age
 
-      ...
-    end
+  ...
+end
 
-    temperance = Person.new('Temperance', 30)
-    temperance.name
+temperance = Person.new('Temperance', 30)
+temperance.name
 
-    puts temperance.age
+puts temperance.age
 
-    x = Math.sin(y)
-    array.delete(e)
+x = Math.sin(y)
+array.delete(e)
 ```
 
 ### Prefer `{...}` over `do...end` for single-line blocks.  Avoid using
@@ -369,145 +369,146 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
   when chaining.
 
 ```ruby
-    names = ['Bozhidar', 'Steve', 'Sarah']
+names = ['Bozhidar', 'Steve', 'Sarah']
 
-    # good
-    names.each { |name| puts name }
+# good
+names.each { |name| puts name }
 
-    # bad
-    names.each do |name|
-      puts name
-    end
+# bad
+names.each do |name|
+  puts name
+end
 
-    # good
-    names.select { |name| name.start_with?('S') }.map { |name| name.upcase }
+# good
+names.select { |name| name.start_with?('S') }.map { |name| name.upcase }
 
-    # bad
-    names.select do |name|
-      name.start_with?('S')
-    end.map { |name| name.upcase }
+# bad
+names.select do |name|
+  name.start_with?('S')
+end.map { |name| name.upcase }
 ```
 
-    Some will argue that multiline chaining would look OK with the use of {...}, but they should
-    ask themselves - it this code really readable and can't the blocks contents be extracted into
-    nifty methods?
+Some will argue that multiline chaining would look OK with the use of {...}, but they should
+ask themselves - it this code really readable and can't the blocks contents be extracted into
+nifty methods?
 
 ### Avoid `return` where not needed for flow of control.
   (Omitting `return` is more succinct and declarative, and your code will still work if you refactor it into a block later.)
 
 ```ruby
-    # bad
-    def some_method(some_arr)
-      return some_arr.size
-    end
+# bad
+def some_method(some_arr)
+  return some_arr.size
+end
 
-    # good
-    def some_method(some_arr)
-      some_arr.size
-    end
+# good
+def some_method(some_arr)
+  some_arr.size
+end
 ```
 
 ### Only use `self` when required for calling a self write accessor.
 
 ```ruby
-    # bad
-    def ready?
-      if self.last_reviewed_at > self.last_updated_at
-        self.worker.update(self.content, self.options)
-        self.status = :in_progress
-      end
-      self.status == :verified
-    end
+# bad
+def ready?
+  if self.last_reviewed_at > self.last_updated_at
+    self.worker.update(self.content, self.options)
+    self.status = :in_progress
+  end
+  self.status == :verified
+end
 
-    # good
-    def ready?
-      if last_reviewed_at > last_updated_at
-        worker.update(content, options)
-        self.status = :in_progress
-      end
-      status == :verified
-    end
+# good
+def ready?
+  if last_reviewed_at > last_updated_at
+    worker.update(content, options)
+    self.status = :in_progress
+  end
+  status == :verified
+end
 ```
 
 ### As a corollary, avoid shadowing methods with local variables unless they are both equivalent
 
 ```ruby
-    class Foo
-      attr_accessor :options
+class Foo
+  attr_accessor :options
 
-      # ok
-      def initialize(options)
-        self.options = options
-        # both options and self.options are equivalent here
-      end
+  # ok
+  def initialize(options)
+    self.options = options
+    # both options and self.options are equivalent here
+  end
 
-      # bad
-      def do_something(options = {})
-        unless options[:when] == :later
-          output(self.options[:message])
-        end
-      end
-
-      # good
-      def do_something(params = {})
-        unless params[:when] == :later
-          output(options[:message])
-        end
-      end
+  # bad
+  def do_something(options = {})
+    unless options[:when] == :later
+      output(self.options[:message])
     end
+  end
+
+  # good
+  def do_something(params = {})
+    unless params[:when] == :later
+      output(options[:message])
+    end
+  end
+end
+```
 
 ### Use spaces around the `=` operator when assigning default values to method parameters:
 
-```Ruby
-    # bad
-    def some_method(arg1=:default, arg2=nil, arg3=[])
-      # do something...
-    end
+```ruby
+# bad
+def some_method(arg1=:default, arg2=nil, arg3=[])
+  # do something...
+end
 
-    # good
-    def some_method(arg1 = :default, arg2 = nil, arg3 = [])
-      # do something...
-    end
-    ```
+# good
+def some_method(arg1 = :default, arg2 = nil, arg3 = [])
+  # do something...
+end
+```
 
-    While several Ruby books suggest the first style, the second is much more prominent
-    in practice (and arguably a bit more readable).
+While several Ruby books suggest the first style, the second is much more prominent
+in practice (and arguably a bit more readable).
 
 ### Avoid line continuation (\\) unless absolutely required.
 
 ```ruby
-    # bad
-    result = 1 \
-             - 2
+# bad
+result = 1 \
+         - 2
 
-    # better
-    result = 1 -
-             2
+# better
+result = 1 -
+         2
 ```
 
 ### Using the return value of `=` (an assignment) is ok, but surround the
   assignment with parentheses to it clear you are not mistakenly using `=` when you meant `==`.
 
 ```ruby
-    # good - shows intended use of assignment
-    if (v = array.grep(/foo/)) ...
+# good - shows intended use of assignment
+if (v = array.grep(/foo/)) ...
 
-    # bad
-    if v = array.grep(/foo/) ...
+# bad
+if v = array.grep(/foo/) ...
 
-    # also good - shows intended use of assignment and has correct precedence.
-    if (v = next_value) == 'hello' ...
+# also good - shows intended use of assignment and has correct precedence.
+if (v = next_value) == 'hello' ...
 ```
 
 ### Don't use `||=` to initialize boolean variables. (Consider what
 would happen if the current value happened to be `false`.)
 
 ```ruby
-    # bad - would set enabled to true even if it was false
-    enabled ||= true
+# bad - would set enabled to true even if it was false
+enabled ||= true
 
-    # good
-    enabled = true if enabled.nil?
+# good
+enabled = true if enabled.nil?
 ```
 
 ### Avoid using Perl-style special variables (like `$0-9`, `$``,
@@ -516,21 +517,21 @@ would happen if the current value happened to be `false`.)
 ### Never put a space between a method name and the opening parenthesis.
 
 ```ruby
-    # bad
-    f (3 + 2) + 1
+# bad
+f (3 + 2) + 1
 
-    # good
-    f(3 + 2) + 1
+# good
+f(3 + 2) + 1
 ```
 
 ### Ruby 1.9 hash literal syntax is preferred when the hash keys are symbols.
 
 ```ruby
-    # bad
-    hash = { :one => 1, :two => 2 }
+# bad
+hash = { :one => 1, :two => 2 }
 
-    # good
-    hash = { one: 1, two: 2 }
+# good
+hash = { one: 1, two: 2 }
 ```
 
 ### `lambda` is preferred over `proc`/`Proc.new`. This is because `lambda`s enforce argument list cardinality and have unsurprising `return` semantics. (Only use `proc` if you really need a return statement that returns from the enclosing code.)  More details [here](http://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Method_Calls#Understanding_blocks.2C_Procs_and_methods).
@@ -538,23 +539,23 @@ would happen if the current value happened to be `false`.)
 ### Ruby 1.9 `lambda` literal syntax is preferred.
 
 ```ruby
-    # bad
-    lambda = lambda { |a, b| a + b }
-    lambda.call(1, 2)
+# bad
+lambda = lambda { |a, b| a + b }
+lambda.call(1, 2)
 
-    # good
-    lambda = ->(a, b) { a + b }
-    lambda.(1, 2)
+# good
+lambda = ->(a, b) { a + b }
+lambda.(1, 2)
 ```
 
 ### Use `_` for unused block parameters.
 
 ```ruby
-    # bad
-    result = hash.map { |k, v| v + 1 }
+# bad
+result = hash.map { |k, v| v + 1 }
 
-    # good
-    result = hash.map { |_, v| v + 1 }
+# good
+result = hash.map { |_, v| v + 1 }
 ```
 
 ## Naming
@@ -604,24 +605,24 @@ would happen if the current value happened to be `false`.)
   Use @@ variables when you want process-wide globals (such as for a process-wide cache).
 
 ```ruby
-    class Parent
-      @@class_var = 'parent'
+class Parent
+  @@class_var = 'parent'
 
-      def self.print_class_var
-        puts @@class_var
-      end
-    end
+  def self.print_class_var
+    puts @@class_var
+  end
+end
 
-    class Child < Parent
-      @@class_var = 'child'
-    end
+class Child < Parent
+  @@class_var = 'child'
+end
 
-    Parent.print_class_var # => will print "child"
+Parent.print_class_var # => will print "child"
 ```
 
-    As you can see all the classes in a class hierarchy actually share one
-    class variable. Class instance variables should usually be preferred
-    over class variables.
+As you can see all the classes in a class hierarchy actually share one
+class variable. Class instance variables should usually be preferred
+over class variables.
 
 ### Assign proper visibility levels to methods (`private`, `protected`)
 in accordance with their intended usage.
@@ -630,44 +631,45 @@ in accordance with their intended usage.
   method definitions they apply to. Leave one blank line above them.
 
 ```ruby
-    class SomeClass
-      def public_method
-        ...
-      end
+class SomeClass
+  def public_method
+    ...
+  end
 
-      private
-      def private_method
-        ...
-      end
-    end
+  private
+  def private_method
+    ...
+  end
+end
+```
 
 ### Use `def self.method` to define singleton methods so you don't have to repeat the class name (Don't Repeat Yourself).
 
-```Ruby
-    class TestClass
-      # bad
-      def TestClass.some_method
-        ...
-      end
+```ruby
+class TestClass
+  # bad
+  def TestClass.some_method
+    ...
+  end
 
-      # good
-      def self.some_other_method
-        ...
-      end
+  # good
+  def self.some_other_method
+    ...
+  end
 
-      # Also possible and convenient when you
-      # have to define many singleton methods.
-      class << self
-        def first_method
-          ...
-        end
-
-        def second_method_etc
-          ...
-        end
-      end
+  # Also possible and convenient when you
+  # have to define many singleton methods.
+  class << self
+    def first_method
+      ...
     end
-    ```
+
+    def second_method_etc
+      ...
+    end
+  end
+end
+```
 
 ## Exceptions
 
@@ -678,162 +680,161 @@ in accordance with their intended usage.
   silently thrown away.
 
 ```ruby
-    def foo
-      begin
-        fail
-      ensure
-        return 'very bad idea'
-      end
-    end
+def foo
+  begin
+    fail
+  ensure
+    return 'very bad idea'
+  end
+end
 ```
 
 ### Use *implicit begin blocks* when possible.
 
 ```ruby
-    # bad
-    def foo
-      begin
-        # main logic goes here
-      rescue
-        # failure handling goes here
-      end
-    end
+# bad
+def foo
+  begin
+    # main logic goes here
+  rescue
+    # failure handling goes here
+  end
+end
 
-    # good
-    def foo
-      # main logic goes here
-    rescue
-      # failure handling goes here
-    end
+# good
+def foo
+  # main logic goes here
+rescue
+  # failure handling goes here
+end
 ```
 
 ### Mitigate the proliferation of `begin` blocks by using
   *contingency methods* (a term coined by Avdi Grimm).
 
 ```ruby
-    # bad
-    begin
-      something_that_might_fail
-    rescue IOError
-      # handle IOError
-    end
+# bad
+begin
+  something_that_might_fail
+rescue IOError
+  # handle IOError
+end
 
-    begin
-      something_else_that_might_fail
-    rescue IOError
-      # handle IOError
-    end
+begin
+  something_else_that_might_fail
+rescue IOError
+  # handle IOError
+end
 
-    # good
-    def with_io_error_handling
-       yield
-    rescue IOError
-      # handle IOError
-    end
+# good
+def with_io_error_handling
+   yield
+rescue IOError
+  # handle IOError
+end
 
-    with_io_error_handling { something_that_might_fail }
+with_io_error_handling { something_that_might_fail }
 
-    with_io_error_handling { something_else_that_might_fail }
+with_io_error_handling { something_else_that_might_fail }
 ```
 
 ### Don't suppress exceptions.
 
 ```ruby
-    # bad
-    begin
-      # an exception occurs here
-    rescue SomeError
-      # the rescue clause does absolutely nothing
-    end
+# bad
+begin
+  # an exception occurs here
+rescue SomeError
+  # the rescue clause does absolutely nothing
+end
 
-    # bad
-    do_something rescue nil
+# bad
+do_something rescue nil
 ```
 
 ### Don't use exceptions for flow of control.
 
 ```ruby
-    # bad
-    begin
-      n / d
-    rescue ZeroDivisionError
-      puts 'Cannot divide by 0!'
-    end
+# bad
+begin
+  n / d
+rescue ZeroDivisionError
+  puts 'Cannot divide by 0!'
+end
 
-    # good
-    if d.zero?
-      puts 'Cannot divide by 0!'
-    else
-      n / d
-    end
+# good
+if d.zero?
+  puts 'Cannot divide by 0!'
+else
+  n / d
+end
 ```
 
 ### Avoid rescuing the `Exception` class.  This will trap signals and calls to
   `exit`, requiring you to `kill -9` the process.
 
 ```ruby
-    # bad
-    begin
-      # calls to exit and kill signals will be caught (except kill -9)
-      exit
-    rescue Exception
-      puts "you didn't really want to exit, right?"
-      # exception handling
-    end
+# bad
+begin
+  # calls to exit and kill signals will be caught (except kill -9)
+  exit
+rescue Exception
+  puts "you didn't really want to exit, right?"
+  # exception handling
+end
 
-    # good
-    begin
-      # a blind rescue rescues from StandardError, not Exception as many
-      # programmers assume.
-    rescue => e
-      # exception handling
-    end
+# good
+begin
+  # a blind rescue rescues from StandardError, not Exception as many
+  # programmers assume.
+rescue => e
+  # exception handling
+end
 
-    # also good
-    begin
-      # an exception occurs here
+# also good
+begin
+  # an exception occurs here
 
-    rescue StandardError => e
-      # exception handling
-    end
-
+rescue StandardError => e
+  # exception handling
+end
 ```
 
 ### Put more specific exceptions higher up the rescue chain, otherwise
   they'll never be rescued from.
 
 ```ruby
-    # bad
-    begin
-      # some code
-    rescue Exception => e
-      # some handling
-    rescue StandardError => e
-      # some handling
-    end
+# bad
+begin
+  # some code
+rescue Exception => e
+  # some handling
+rescue StandardError => e
+  # some handling
+end
 
-    # good
-    begin
-      # some code
-    rescue StandardError => e
-      # some handling
-    rescue Exception => e
-      # some handling
-    end
+# good
+begin
+  # some code
+rescue StandardError => e
+  # some handling
+rescue Exception => e
+  # some handling
+end
 ```
 
 ### Release external resources obtained by your program in an ensure
 block.
 
 ```ruby
-    f = File.open('testfile')
-    begin
-      # .. process
-    rescue
-      # .. handle error
-    ensure
-      f.close unless f.nil?
-    end
+f = File.open('testfile')
+begin
+  # .. process
+rescue
+  # .. handle error
+ensure
+  f.close unless f.nil?
+end
 ```
 
 ### Use exceptions from the standard library for simple cases so you can avoid
@@ -856,42 +857,42 @@ introducing new exception classes.
 ### Prefer string interpolation instead of string concatenation:
 
 ```ruby
-    # bad
-    email_with_name = user.name + ' <' + user.email + '>'
+# bad
+email_with_name = user.name + ' <' + user.email + '>'
 
-    # good
-    email_with_name = "#{user.name} <#{user.email}>"
+# good
+email_with_name = "#{user.name} <#{user.email}>"
 ```
 
 ### Consider padding string interpolation code with space. It more clearly sets the
   code apart from the string.
 
 ```ruby
-    "#{ user.last_name }, #{ user.first_name }"
+"#{ user.last_name }, #{ user.first_name }"
 ```
 
 ### `String#<<` performs better by mutating the string in place.  `String#+`, avoids mutation (which is good
   in a functional way) but therefore runs slower since it creates a new string object.
 
 ```ruby
-    # faster
-    html = ''
+# faster
+html = ''
 
-    paragraphs.each do |paragraph|
-      html << "<p>#{paragraph}</p>"
-    end
-    
-    # more functional but slower
-    html = ''
+paragraphs.each do |paragraph|
+  html << "<p>#{paragraph}</p>"
+end
 
-    paragraphs.each do |paragraph|
-      html += "<p>#{paragraph}</p>"
-    end
-    
-    # most functional
-    html = paragraphs.map do |paragraph|
-      "<p>#{paragraph}</p>"
-    end.join
+# more functional but slower
+html = ''
+
+paragraphs.each do |paragraph|
+  html += "<p>#{paragraph}</p>"
+end
+
+# most functional
+html = paragraphs.map do |paragraph|
+  "<p>#{paragraph}</p>"
+end.join
 ```
 
 ## Regular Expressions
@@ -899,43 +900,43 @@ introducing new exception classes.
 ### Don't use a regular expression when a plain string will do:
 
 ```ruby
-    # bad
-    if command[/quit/]
-      ...
-    end
-    
-    # good
-    if command['quit']
-      ...
-    end
+# bad
+if command[/quit/]
+  ...
+end
+
+# good
+if command['quit']
+  ...
+end
 ```
   
 ### For simple constructions you can use regexp directly through string index.
 
 ```ruby
-    match = string[/regexp/]             # get content of matched regexp
-    first_group = string[/text(grp)/, 1] # get content of captured group
-    string[/text (grp)/, 1] = 'replace'  # string => 'text replace'
+match = string[/regexp/]             # get content of matched regexp
+first_group = string[/text(grp)/, 1] # get content of captured group
+string[/text (grp)/, 1] = 'replace'  # string => 'text replace'
 ```
 
 ### Avoid using $1-9 as it can be hard to track what they contain and they live globally. Numbered indexes
   or named groups can be used instead.
 
 ```ruby
-    # bad
-    /\A(https?):/ =~ url
-    ...
-    setup_connection($1)
-    
-    # good
-    protocol = url[/\A(https?):/, 1]
-    ...
-    setup_connection(protocol)
+# bad
+/\A(https?):/ =~ url
+...
+setup_connection($1)
 
-    # good
-    /\A(?<protocol>https?):/ =~ url
-    ...
-    setup_connection(protocol)
+# good
+protocol = url[/\A(https?):/, 1]
+...
+setup_connection(protocol)
+
+# good
+/\A(?<protocol>https?):/ =~ url
+...
+setup_connection(protocol)
 ```
 
 ### Be careful not to use `^` and `$` for anchors (like in other languages) because in
@@ -944,22 +945,22 @@ introducing new exception classes.
   confused with `\Z` which is the equivalent of `/\n?\z/`).
 
 ```ruby
-    string = "some injection\nusername"
-    string[/^username$/]   # matches
-    string[/\Ausername\z/] # don't match
+string = "some injection\nusername"
+string[/^username$/]   # matches
+string[/\Ausername\z/] # don't match
 ```
 
 ### Use `x` modifier for complex regexps so that you can use whitespace and comments to
   make them more readable. Just be careful as spaces are ignored.
 
 ```ruby
-    regexp = %r{
-      start         # some text
-      \s            # white space char
-      (group)       # first group
-      (?:alt1|alt2) # some alternation
-      end
-    }x
+regexp = %r{
+  start         # some text
+  \s            # white space char
+  (group)       # first group
+  (?:alt1|alt2) # some alternation
+  end
+}x
 ```
 
 ### For complex replacements `sub`/`gsub` can be used with a block or hash.
@@ -972,22 +973,21 @@ introducing new exception classes.
 ### Do not monkey patch core classes unless you really need to change their behavior
   generally across all code in the process including other gems and libraries (separation of concerns!):
 
-    ```ruby
-    # bad
-    class Fixnum
-      def days
-        ...
-      end
-    end
-    
-    ```
+```ruby
+# bad
+class Fixnum
+  def days
+    ...
+  end
+end
+```
 
 ### The block form of `class_eval` is preferable to the string-interpolated form.
   - when you use the string-interpolated form, always supply `__FILE__` and `__LINE__`, so that your backtraces make sense:
 
-    ```ruby
-    class_eval 'def use_relative_model_naming?; true; end', __FILE__, __LINE__
-    ```
+```ruby
+class_eval 'def use_relative_model_naming?; true; end', __FILE__, __LINE__
+```
 
   - `define_method` is preferable to `class_eval { def ... }`
 
@@ -997,27 +997,27 @@ introducing new exception classes.
   - call `super` at the end of your statement
   - delegate to a reusable, testable, non-magical method:
 
-    ```ruby
-    # bad
-    def method_missing?(meth, *args, &block)
-      if /^find_by_(?<prop>.*)/ =~ meth
-        # ... lots of code to do a find_by
-      else
-        super
-      end
-    end
+```ruby
+# bad
+def method_missing?(meth, *args, &block)
+  if /^find_by_(?<prop>.*)/ =~ meth
+    # ... lots of code to do a find_by
+  else
+    super
+  end
+end
 
-    # good
-    def method_missing?(meth, *args, &block)
-      if /^find_by_(?<prop>.*)/ =~ meth
-        find_by(prop, *args, &block)
-      else
-        super
-      end
-    end
+# good
+def method_missing?(meth, *args, &block)
+  if /^find_by_(?<prop>.*)/ =~ meth
+    find_by(prop, *args, &block)
+  else
+    super
+  end
+end
 
-    # best of all, though, would be to define_method as each findable attribute is declared
-    ```
+# best of all, though, would be to define_method as each findable attribute is declared
+```
 
 ## Misc
 
@@ -1025,8 +1025,8 @@ introducing new exception classes.
 ### When code patterns are repeated, use separate lines and extra whitespace when practical to align columns
   so that the code is tabular.  This makes the patterns obvious which helps to spot/prevent bugs.
 
-    ```ruby
-    # bad
+```ruby
+# bad
     PROMOTIONAL_METHODS = [
                     [ 'review_site', 'Content / Review Site'],
                     [ 'coupon_site', 'Discount / Coupon Site' ],
@@ -1078,7 +1078,7 @@ introducing new exception classes.
             'Zipcode'       => zip
           }
 
-    ```
+```
  
 ### Prefer code written in the functional style:  avoid side-effects like object mutation unless required by performance concerns.
   Mutating arguments is a side-effect so don't do it unless that is the sole purpose of the method.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 * [Collections](#collections)
 * [Strings](#strings)
 * [Regular Expressions](#regular-expressions)
-* [Percent Literals](#percent-literals)
 * [Metaprogramming](#metaprogramming)
 * [Misc](#misc)
 
@@ -153,11 +152,11 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 
      ```Ruby
      def some_method
-       # body omitted
+       ...
      end
 
      def some_method_with_arguments(arg1, arg2)
-       # body omitted
+       ...
      end
      ```
 
@@ -184,18 +183,19 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     ```Ruby
     # bad
     if some_condition then
-      # body omitted
+      ...
     end
 
     # good
     if some_condition
-      # body omitted
+      ...
     end
     ```
 
 * Use one expression per branch in a ternary operator. This
   also means that ternary operators must not be nested. Prefer
   `if/else` constructs in these cases.
+  Avoid multi-line ternary; use `if/unless` instead.
 
     ```Ruby
     # bad
@@ -244,8 +244,6 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     (flag = top_of_page?) or reset_page
     
     ```
-  
-* Avoid multi-line `?:` (the ternary operator); use `if/unless` instead.
 
 * Only use trailing `if/unless` when they are rare footnotes that can be
   ignored in the usual, "go-right" case.  That is, the statement you start with should
@@ -305,17 +303,17 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     ```Ruby
     # bad
     if (x > 10)
-      # body omitted
+      ...
     end
 
     # good
     if x > 10
-      # body omitted
+      ...
     end
 
     # ok
     if (x = self.next_value)
-      # body omitted
+      ...
     end
     ```
 
@@ -352,7 +350,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     class Person
       attr_reader :name, :age
 
-      # omitted
+      ...
     end
 
     temperance = Person.new('Temperance', 30)
@@ -392,10 +390,10 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 
     Some will argue that multiline chaining would look OK with the use of {...}, but they should
     ask themselves - it this code really readable and can't the blocks contents be extracted into
-    nifty methods.
+    nifty methods?
 
-* Avoid `return` where not required.
-  It's more succinct, and will still work if you refactor your code into a block later.
+* Avoid `return` where not needed for flow of control.
+  Omitting `return` is more succinct and declarative, and your code will still work if you refactor it into a block later.
 
     ```Ruby
     # bad
@@ -409,7 +407,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     end
     ```
 
-* Avoid `self` where not required. (It is only required when calling a self write accessor.)
+* Only use `self` when required for calling a self write accessor.
 
     ```Ruby
     # bad
@@ -498,14 +496,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     if v = array.grep(/foo/) ...
 
     # also good - shows intended use of assignment and has correct precedence.
-    if (v = self.next_value) == 'hello' ...
-    ```
-
-* Use `||=` to initialize variables the first time.
-
-    ```Ruby
-    # set name to Bozhidar, only if it's nil or false
-    name ||= 'Bozhidar'
+    if (v = next_value) == 'hello' ...
     ```
 
 * Don't use `||=` to initialize boolean variables. (Consider what
@@ -595,8 +586,6 @@ would happen if the current value happened to be `false`.)
 
 ## Classes
 
-* When designing class hierarchies make sure that they conform to the
-  [Liskov Substitution Principle](http://en.wikipedia.org/wiki/Liskov_substitution_principle).
 * Try to make your classes as
   [SOLID](http://en.wikipedia.org/wiki/SOLID_(object-oriented_design\))
   as possible.
@@ -634,12 +623,12 @@ in accordance with their intended usage.
     ```Ruby
     class SomeClass
       def public_method
-        # ...
+        ...
       end
 
       private
       def private_method
-        # ...
+        ...
       end
     end
 
@@ -649,23 +638,23 @@ in accordance with their intended usage.
     class TestClass
       # bad
       def TestClass.some_method
-        # body omitted
+        ...
       end
 
       # good
       def self.some_other_method
-        # body omitted
+        ...
       end
 
       # Also possible and convenient when you
       # have to define many singleton methods.
       class << self
         def first_method
-          # body omitted
+          ...
         end
 
         def second_method_etc
-          # body omitted
+          ...
         end
       end
     end
@@ -977,32 +966,6 @@ introducing new exception classes.
 
 * For complex replacements `sub`/`gsub` can be used with a block or hash.
 
-## Percent Literals
-
-* Use `%()` for single-line strings which require both interpolation
-  and embedded double-quotes. For multi-line strings, prefer << heredocs.
-
-    ```Ruby
-    # bad (no interpolation needed)
-    %(<div class="text">Some text</div>)
-    # should be '<div class="text">Some text</div>'
-
-    # bad (no double-quotes)
-    %(This is #{quality} style)
-    # should be "This is #{quality} style"
-
-    # bad (multiple lines)
-    %(<div>\n<span class="big">#{exclamation}</span>\n</div>)
-    # should be a heredoc.
-
-    # good (requires interpolation, has quotes, single line)
-    %(<tr><td class="name">#{name}</td>)
-    ```
-
-* Avoid `%q`, `%Q`, `%x`, `%s`, and `%W`.
-
-* Prefer `()` as delimiters for all `%` literals.
-
 ## Metaprogramming
 
 * Only use metaprogramming when necessary.  For example, `deliver_<mail_message>` in TMail was completely
@@ -1029,26 +992,6 @@ introducing new exception classes.
     ```
 
   - `define_method` is preferable to `class_eval { def ... }`
-
-* When using `class_eval` (or other `eval`) with string interpolation, add a comment block showing its appearance if interpolated (a practice I learned from the rails code):
-
-    ```ruby
-    # from activesupport/lib/active_support/core_ext/string/output_safety.rb
-    UNSAFE_STRING_METHODS.each do |unsafe_method|
-      if 'String'.respond_to?(unsafe_method)
-        class_eval <<-EOT, __FILE__, __LINE__ + 1
-          def #{unsafe_method}(*args, &block)       # def capitalize(*args, &block)
-            to_str.#{unsafe_method}(*args, &block)  #   to_str.capitalize(*args, &block)
-          end                                       # end
-
-          def #{unsafe_method}!(*args)              # def capitalize!(*args)
-            @dirty = true                           #   @dirty = true
-            super                                   #   super
-          end                                       # end
-        EOT
-      end
-    end
-    ```
 
 * Avoid `method_missing` if possible. Backtraces become messy; the behavior is not listed in `#methods`; misspelled method calls might silently work (`nukes.launch_state = false`). Consider using delegation, proxy, or `define_method` instead.  If you must, use `method_missing`,
   - be sure to [also define `respond_to_missing?`](http://blog.marc-andre.ca/2010/11/methodmissing-politely.html)

--- a/README.md
+++ b/README.md
@@ -533,7 +533,9 @@ would happen if the current value happened to be `false`.)
     hash = { one: 1, two: 2 }
     ```
 
-* Ruby 1.9 lambda literal syntax is preferred.
+* `lambda` is preferred over `proc`/`Proc.new`. This is because `lambda`s enforce argument list cardinality and have unsurprising `return` semantics. (Only use `proc` if you really need a return statement that returns from the enclosing code.)  More details [here](http://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Method_Calls#Understanding_blocks.2C_Procs_and_methods).
+
+* Ruby 1.9 `lambda` literal syntax is preferred.
 
     ```Ruby
     # bad

--- a/README.md
+++ b/README.md
@@ -1,59 +1,5 @@
 # Prelude
-
-> Style is what separates the good from the great. <br/>
-> -- Bozhidar Batsov
-
-One thing has always bothered me as Ruby developer - Python developers
-have a great programming style reference
-([PEP-8](http://www.python.org/dev/peps/pep-0008/)) and we never got
-an official guide, documenting Ruby coding style and best
-practices. And I do believe that style matters. I also believe that
-such fine fellows, like us Ruby developers, should be quite capable to
-produce this coveted document.
-
-This guide started its life as our internal company Ruby coding guidelines
-(written by yours truly). At some point I decided that the work I was
-doing might be interesting to members of the Ruby community in general
-and that the world had little need for another internal company
-guideline. But the world could certainly benefit from a
-community-driven and community-sanctioned set of practices, idioms and
-style prescriptions for Ruby programming.
-
-Since the inception of the guide I've received a lot of feedback from
-members of the exceptional Ruby community around the world. Thanks for
-all the suggestions and the support! Together we can make a resource
-beneficial to each and every Ruby developer out there.
-
-By the way, if you're into Rails you might want to check out the
-complementary
-[Ruby on Rails 3 Style Guide](https://github.com/RingRevenue/rails-style-guide).
-
-# The Ruby Style Guide
-
-This Ruby style guide recommends best practices so that real-world Ruby
-programmers can write code that can be maintained by other real-world Ruby
-programmers. A style guide that reflects real-world usage gets used, and a
-style guide that holds to an ideal that has been rejected by the people it is
-supposed to help risks not getting used at all &ndash; no matter how good it is.
-
-The guide is separated into several sections of related rules. I've
-tried to add the rationale behind the rules (if it's omitted I've
-assumed that is pretty obvious).
-
-I didn't come up with all the rules out of nowhere - they are mostly
-based on my extensive career as a professional software engineer,
-feedback and suggestions from members of the Ruby community and
-various highly regarded Ruby programming resources, such as
-["Programming Ruby 1.9"](http://pragprog.com/book/ruby3/programming-ruby-1-9)
-and ["The Ruby Programming Language"](http://www.amazon.com/Ruby-Programming-Language-David-Flanagan/dp/0596516177).
-
-The guide is still a work in progress - some rules are lacking
-examples, some rules don't have examples that illustrate them clearly
-enough. In due time these issues will be addressed - just keep them in
-mind for now.
-
-You can generate a PDF or an HTML copy of this guide using
-[Transmuter](https://github.com/TechnoGate/transmuter).
+RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ruby-style-guide.
 
 ## Table of Contents
 
@@ -73,13 +19,7 @@ You can generate a PDF or an HTML copy of this guide using
 
 ## Source Code Layout
 
-> Nearly everybody is convinced that every style but their own is
-> ugly and unreadable. Leave out the "but their own" and they're
-> probably right... <br/>
-> -- Jerry Coffin (on indentation)
-
-* Use `UTF-8` as the source file encoding.
-* Use two **spaces** per indentation level.
+* Use two **spaces** per indentation level. No tabs.
 
     ```Ruby
     # good
@@ -92,14 +32,6 @@ You can generate a PDF or an HTML copy of this guide using
         do_something
     end
     ```
-
-* Use Unix-style line endings. (*BSD/Solaris/Linux/OSX users are covered by default,
-  Windows users have to be extra careful.)
-    * If you're using Git you might want to add the following
-    configuration setting to protect your project from Windows line
-    endings creeping in:
-
-        $ git config --global core.autocrlf true
 
 * Use spaces around operators, after commas, colons and semicolons, around `{`
   and before `}`. Whitespace might be (mostly) irrelevant to the Ruby
@@ -210,8 +142,9 @@ You can generate a PDF or an HTML copy of this guide using
 
 * Use RDoc and its conventions for API documentation.  Don't put an
   empty line between the comment block and the `def`.
-* Keep lines fewer than 80 characters.
+* Avoid lines longer than 120 characters.
 * Avoid trailing whitespace.
+* Use `UTF-8` as the source file encoding when you need more than plain ASCII.
 
 ## Syntax
 
@@ -260,17 +193,6 @@ You can generate a PDF or an HTML copy of this guide using
     end
     ```
 
-* Favor the ternary operator(`?:`) over `if/then/else/end` constructs.
-  It's more common and obviously more concise.
-
-    ```Ruby
-    # bad
-    result = if some_condition then something else something_else end
-
-    # good
-    result = some_condition ? something : something_else
-    ```
-
 * Use one expression per branch in a ternary operator. This
   also means that ternary operators must not be nested. Prefer
   `if/else` constructs in these cases.
@@ -287,7 +209,7 @@ You can generate a PDF or an HTML copy of this guide using
     end
     ```
 
-* Never use `if x: ...` - it is removed in Ruby 1.9. Use
+* Never use `if x: ...` - it is removed in Ruby 1.9. Use multi-line if or
   the ternary operator instead.
 
     ```Ruby
@@ -298,46 +220,53 @@ You can generate a PDF or an HTML copy of this guide using
     result = some_condition ? something : something_else
     ```
 
-* Never use `if x; ...`. Use the ternary operator instead.
-
 * Use `when x then ...` for one-line cases. The alternative syntax
   `when x: ...` is removed in Ruby 1.9.
 
-* Never use `when x; ...`. See the previous rule.
-
-* Use `&&/||` for boolean expressions, `and/or` for control flow.  (Rule
-  of thumb: If you have to use outer parentheses, you are using the
-  wrong operators.)
+* Use `&&/||` for boolean expressions, `and/or` for control flow.
 
     ```Ruby
     # boolean expression
-    if some_condition && some_other_condition
-      do_something
+    if document.text_changed? || document.settings_changed?
+      document.save!
     end
 
     # control flow
     document.saved? or document.save!
     ```
 
-* Avoid multi-line `?:` (the ternary operator), use `if/unless` instead.
+  Beware: `and/or` have lower precedence than `=`!
+  
+    ```Ruby
+    flag = top_of_page? or reset_page
+    
+    # is equivalent to
+    (flag = top_of_page?) or reset_page
+    
+    ```
+  
+* Avoid multi-line `?:` (the ternary operator); use `if/unless` instead.
 
-* Favor modifier `if/unless` usage when you have a single-line
-  body. Another good alternative is the usage of control flow `and/or`.
+* Only use trailing `if/unless` when they are are rare footnotes that can be
+  ignored in the usual, "go-right" case.  That is, the statement you start with should
+  almost always execute.
+  (A good alternative for assertions and other one-line code that rarely executes is control-flow `and/or`.)
 
     ```Ruby
-    # bad
-    if some_condition
-      do_something
-    end
+    # bad -- the raise rarely executes
+    raise ArgumentError, "name must be provided" unless name.present?
 
     # good
-    do_something if some_condition
+    name.present? or raise ArgumentError, "name must be provided" 
 
-    # another good option
-    some_condition and do_something
+    # good -- the unless is a rare footnote
+    formt(page) unless page.already_formatted?
+    
+    # good -- the if is almost always true
+    send_notification(users) if users.any?
     ```
 
-* Favor `unless` over `if` for negative conditions (or control
+* Favor `unless` over `if` for negative conditions (or use control
   flow `or`).
 
     ```Ruby
@@ -466,6 +395,7 @@ You can generate a PDF or an HTML copy of this guide using
     nifty methods.
 
 * Avoid `return` where not required.
+  It's more succinct, and will still work if you refactor your code into a block later.
 
     ```Ruby
     # bad
@@ -479,7 +409,7 @@ You can generate a PDF or an HTML copy of this guide using
     end
     ```
 
-* Avoid `self` where not required.
+* Avoid `self` where not required. (It is only required when calling a self write accessor.)
 
     ```Ruby
     # bad
@@ -495,7 +425,7 @@ You can generate a PDF or an HTML copy of this guide using
     def ready?
       if last_reviewed_at > last_updated_at
         worker.update(content, options)
-        status = :in_progress
+        self.status = :in_progress
       end
       status == :verified
     end
@@ -545,21 +475,20 @@ You can generate a PDF or an HTML copy of this guide using
     While several Ruby books suggest the first style, the second is much more prominent
     in practice (and arguably a bit more readable).
 
-* Avoid line continuation (\\) where not required. In practice, avoid using
-  line continuations at all.
+* Avoid line continuation (\\) unless absolutely required.
 
     ```Ruby
     # bad
-    result = 1 - \
-             2
-
-    # good (but still ugly as hell)
     result = 1 \
              - 2
+
+    # better
+    result = 1 -
+             2
     ```
 
 * Using the return value of `=` (an assignment) is ok, but surround the
-  assignment with parenthesis.
+  assignment with parentheses to it clear you are not mistakenly using `=` when you meant `==`.
 
     ```Ruby
     # good - shows intended use of assignment
@@ -572,7 +501,7 @@ You can generate a PDF or an HTML copy of this guide using
     if (v = self.next_value) == 'hello' ...
     ```
 
-* Use `||=` freely to initialize variables.
+* Use `||=` to initialize variables the first time.
 
     ```Ruby
     # set name to Bozhidar, only if it's nil or false
@@ -591,8 +520,7 @@ would happen if the current value happened to be `false`.)
     ```
 
 * Avoid using Perl-style special variables (like `$0-9`, `$``,
-  etc. ). They are quite cryptic and their use in anything but
-  one-liner scripts is discouraged.
+  etc. ). They are cryptic and global.
 
 * Never put a space between a method name and the opening parenthesis.
 
@@ -604,15 +532,7 @@ would happen if the current value happened to be `false`.)
     f(3 + 2) + 1
     ```
 
-* If the first argument to a method begins with an open parenthesis,
-  always use parentheses in the method invocation. For example, write
-`f((3 + 2) + 1)`.
-
-* Always run the Ruby interpreter with the `-w` option so it will warn
-you if you forget either of the rules above!
-
-* When the keys of your hash are symbols use the Ruby 1.9 hash literal
-syntax.
+* Ruby 1.9 hash literal syntax is preferred when the hash keys are symbols.
 
     ```Ruby
     # bad
@@ -622,7 +542,7 @@ syntax.
     hash = { one: 1, two: 2 }
     ```
 
-* Use the new lambda literal syntax.
+* Ruby 1.9 lambda literal syntax is preferred.
 
     ```Ruby
     # bad
@@ -646,10 +566,6 @@ syntax.
 
 ## Naming
 
-> The only real difficulties in programming are cache invalidation and
-> naming things. <br/>
-> -- Phil Karlton
-
 * Use `snake_case` for methods and variables.
 * Use `CamelCase` for classes and modules.  (Keep acronyms like HTTP,
   RFC, XML uppercase.)
@@ -657,71 +573,14 @@ syntax.
 * The names of predicate methods (methods that return a boolean value)
   should end in a question mark.
   (i.e. `Array#empty?`).
-* The names of potentially "dangerous" methods (i.e. methods that modify `self` or the
-  arguments, `exit!` (doesn't run the finalizers like `exit` does), etc.) should end with an exclamation mark if
-  there exists a safe version of that *dangerous* method.
+* The names of potentially "dangerous" or surprising methods (e.g. methods that have side-effects like mutating a variable
+  or changing the process flow) should end with an exclamation mark.
 
-    ```Ruby
-    # bad - there is not matching 'safe' method
-    class Person
-      def update!
-      end
-    end
-
-    # good
-    class Person
-      def update
-      end
-    end
-
-    # good
-    class Person
-      def update!
-      end
-
-      def update
-      end
-    end
-    ```
-
-* Define the non-bang (safe) method in terms of the bang (dangerous)
-  one if possible.
-
-    ```Ruby
-    class Array
-      def flatten_once!
-        res = []
-
-        each do |e|
-          [*e].each { |f| res << f }
-        end
-
-        replace(res)
-      end
-
-      def flatten_once
-        dup.flatten_once!
-      end
-    end
-    ```
-
-* When using `reduce` with short blocks, name the arguments `|a, e|`
-  (accumulator, element).
-* When defining binary operators, name the argument `other`.
-
-    ```Ruby
-    def +(other)
-      # body omitted
-    end
-    ```
-
-* Prefer `map` over `collect`, `find` over `detect`, `select` over
-  `find_all`, `reduce` over `inject` and `size` over `length`. This is
-  not a hard requirement; if the use of the alias enhances
-  readability, it's ok to use it. The rhyming methods are inherited from
-  Smalltalk and are not common in other programming languages. The
-  reason the use of `select` is encouraged over `find_all` is that it
-  goes together nicely with `reject` and its name is pretty self-explanatory.
+* Prefer
+  * `map` over `collect`
+  * `find` over `detect`
+  * `select` over `find_all`
+  * `size` over `length`
 
 ## Comments
 
@@ -731,64 +590,8 @@ syntax.
 > it even clearer. <br/>
 > -- Steve McConnell
 
-* Write self-documenting code and ignore the rest of this section. Seriously!
-* Comments longer than a word are capitalized and use punctuation. Use [one
-  space](http://en.wikipedia.org/wiki/Sentence_spacing) after periods.
-* Avoid superfluous comments.
+* Enough said.
 
-    ```Ruby
-    # bad
-    counter += 1 # increments counter by one
-    ```
-
-* Keep existing comments up-to-date. An outdated is worse than no comment
-at all.
-
-> Good code is like a good joke - it needs no explanation. <br/>
-> -- Russ Olsen
-
-* Avoid writing comments to explain bad code. Refactor the code to
-  make it self-explanatory. (Do or do not - there is no try. --Yoda)
-
-## Annotations
-
-* Annotations should usually be written on the line immediately above
-  the relevant code.
-* The annotation keyword is followed by a colon and a space, then a note
-  describing the problem.
-* If multiple lines are required to describe the problem, subsequent
-  lines should be indented two spaces after the `#`.
-
-    ```Ruby
-    def bar
-      # FIXME: This has crashed occasionally since v3.2.1. It may
-      #   be related to the BarBazUtil upgrade.
-      baz(:quux)
-    end
-    ```
-
-* In cases where the problem is so obvious that any documentation would
-  be redundant, annotations may be left at the end of the offending line
-  with no note. This usage should be the exception and not the rule.
-
-    ```Ruby
-    def bar
-      sleep 100 # OPTIMIZE
-    end
-    ```
-
-* Use `TODO` to note missing features or functionality that should be
-  added at a later date.
-* Use `FIXME` to note broken code that needs to be fixed.
-* Use `OPTIMIZE` to note slow or inefficient code that may cause
-  performance problems.
-* Use `HACK` to note code smells where questionable coding practices
-  were used and should be refactored away.
-* Use `REVIEW` to note anything that should be looked at to confirm it
-  is working as intended. For example: `REVIEW: Are we sure this is how the
-  client does X currently?`
-* Use other custom annotation keywords if it feels appropriate, but be
-  sure to document them in your project's `README` or similar.
 
 ## Classes
 
@@ -797,124 +600,10 @@ at all.
 * Try to make your classes as
   [SOLID](http://en.wikipedia.org/wiki/SOLID_(object-oriented_design\))
   as possible.
-* Always supply a proper `to_s` method for classes that represent
-  domain objects.
 
-    ```Ruby
-    class Person
-      attr_reader :first_name, :last_name
 
-      def initialize(first_name, last_name)
-        @first_name = first_name
-        @last_name = last_name
-      end
-
-      def to_s
-        "#@first_name #@last_name"
-      end
-    end
-    ```
-
-* Use the `attr` family of functions to define trivial accessors or
-mutators.
-
-    ```Ruby
-    # bad
-    class Person
-      def initialize(first_name, last_name)
-        @first_name = first_name
-        @last_name = last_name
-      end
-
-      def first_name
-        @first_name
-      end
-
-      def last_name
-        @last_name
-      end
-    end
-
-    # good
-    class Person
-      attr_reader :first_name, :last_name
-
-      def initialize(first_name, last_name)
-        @first_name = first_name
-        @last_name = last_name
-      end
-    end
-    ```
-* Consider using `Struct.new`, which defines the trivial accessors,
-constructor and comparison operators for you.
-
-    ```Ruby
-    # good
-    class Person
-      attr_reader :first_name, :last_name
-
-      def initialize(first_name, last_name)
-        @first_name = first_name
-        @last_name = last_name
-      end
-    end
-
-    # better
-    class Person < Struct.new(:first_name, :last_name)
-    end
-    ````
-
-* Consider adding factory methods to provide additional sensible ways
-to create instances of a particular class.
-
-    ```Ruby
-    class Person
-      def self.create(options_hash)
-        # body omitted
-      end
-    end
-    ```
-
-* Prefer [duck-typing](http://en.wikipedia.org/wiki/Duck_typing) over inheritance.
-
-    ```Ruby
-    # bad
-    class Animal
-      # abstract method
-      def speak
-      end
-    end
-
-    # extend superclass
-    class Duck < Animal
-      def speak
-        puts 'Quack! Quack'
-      end
-    end
-
-    # extend superclass
-    class Dog < Animal
-      def speak
-        puts 'Bau! Bau!'
-      end
-    end
-
-    # good
-    class Duck
-      def speak
-        puts 'Quack! Quack'
-      end
-    end
-
-    class Dog
-      def speak
-        puts 'Bau! Bau!'
-      end
-    end
-    ```
-
-* Avoid the usage of class (`@@`) variables due to their "nasty" behavior
-in inheritance.
+* Use @ class variables when you want separate values per subclass.
+  Use @@ variables when you want process-wide globals (such as for a process-wide cache).
 
     ```Ruby
     class Parent
@@ -937,9 +626,8 @@ in inheritance.
     over class variables.
 
 * Assign proper visibility levels to methods (`private`, `protected`)
-in accordance with their intended usage. Don't go off leaving
-everything `public` (which is the default). After all we're coding
-in *Ruby* now, not in *Python*.
+in accordance with their intended usage.
+
 * Indent the `public`, `protected`, and `private` methods as much the
   method definitions they apply to. Leave one blank line above them.
 
@@ -955,8 +643,7 @@ in *Ruby* now, not in *Python*.
       end
     end
 
-* Use `def self.method` to define singleton methods. This makes the methods
-  more resistant to refactoring changes.
+* Use `def self.method` to define singleton methods so you don't have to repeat the class name (Don't Repeat Yourself).
 
     ```Ruby
     class TestClass
@@ -985,17 +672,6 @@ in *Ruby* now, not in *Python*.
     ```
 
 ## Exceptions
-
-* Signal exceptions using the `fail` keyword. Use `raise` only when
-  catching an exception and re-raising it (because here you're not failing, but explicitly and purposefully raising an exception).
-
-    ```Ruby
-    begin
-      fail 'Oops';
-    rescue => error
-      raise if error.message != 'Oops'
-    end
-    ```
 
 * Never return from an `ensure` block. If you explicitly return from a
   method inside an `ensure` block, the return will take precedence over
@@ -1033,7 +709,7 @@ in *Ruby* now, not in *Python*.
     end
     ```
 
-* Mitigate the proliferation of `begin` blocks via the use of
+* Mitigate the proliferation of `begin` blocks by using
   *contingency methods* (a term coined by Avdi Grimm).
 
     ```Ruby
@@ -1162,67 +838,17 @@ block.
     end
     ```
 
-* Favor the use of exceptions for the standard library over
+* Use exceptions from the standard library for simple cases so you can avoid
 introducing new exception classes.
 
 ## Collections
-
-* Prefer literal array and hash creation notation (unless you need to
-pass parameters to their constructors, that is).
-
-    ```Ruby
-    # bad
-    arr = Array.new
-    hash = Hash.new
-
-    # good
-    arr = []
-    hash = {}
-    ```
-
-* Prefer `%w` to the literal array syntax when you need an array of
-strings.
-
-    ```Ruby
-    # bad
-    STATES = ['draft', 'open', 'closed']
-
-    # good
-    STATES = %w(draft open closed)
-    ```
-
-* Avoid the creation of huge gaps in arrays.
-
-    ```Ruby
-    arr = []
-    arr[100] = 1 # now you have an array with lots of nils
-    ```
 
 * Use `Set` instead of `Array` when dealing with unique elements. `Set`
   implements a collection of unordered values with no duplicates. This
   is a hybrid of `Array`'s intuitive inter-operation facilities and
   `Hash`'s fast lookup.
-* Use symbols instead of strings as hash keys.
-
-    ```Ruby
-    # bad
-    hash = { 'one' => 1, 'two' => 2, 'three' => 3 }
-
-    # good
-    hash = { one: 1, two: 2, three: 3 }
-    ```
 
 * Avoid the use of mutable object as hash keys.
-* Use the new 1.9 literal hash syntax in preference to the hashrocket
-syntax.
-
-    ```Ruby
-    # bad
-    hash = { :one => 1, :two => 2, :three => 3 }
-
-    # good
-    hash = { one: 1, two: 2, three: 3 }
-    ```
 
 * Rely on the fact that hashes in 1.9 are ordered.
 * Never modify a collection while traversing it.
@@ -1257,48 +883,46 @@ syntax.
     name = 'Bozhidar'
     ```
 
-* Don't use `{}` around instance variables being interpolated into a
-  string.
+* `String#<<` performs better by mutating the string in place.  `String#+`, avoids mutation (which is good
+  in a functional way) but therefore runs slower since it creates a new string object.
 
     ```Ruby
-    class Person
-      attr_reader :first_name, :last_name
-
-      def initialize(first_name, last_name)
-        @first_name = first_name
-        @last_name = last_name
-      end
-
-      # bad
-      def to_s
-        "#{@first_name} #{@last_name}"
-      end
-
-      # good
-      def to_s
-        "#@first_name #@last_name"
-      end
-    end
-    ```
-
-* Avoid using `String#+` when you need to construct large data chunks.
-  Instead, use `String#<<`. Concatenation mutates the string instance in-place
-  and is always faster than `String#+`, which creates a bunch of new string objects.
-
-    ```Ruby
-    # good and also fast
+    # faster
     html = ''
-    html << '<h1>Page title</h1>'
 
     paragraphs.each do |paragraph|
       html << "<p>#{paragraph}</p>"
     end
+    
+    # more functional but slower
+    html = ''
+
+    paragraphs.each do |paragraph|
+      html += "<p>#{paragraph}</p>"
+    end
+    
+    # most functional
+    html = paragraphs.map do |paragraph|
+      "<p>#{paragraph}</p>"
+    end.join
     ```
 
 ## Regular Expressions
 
-* Don't use regular expressions if you just need plain text search in string:
-  `string['text']`
+* Don't use a regular expression when a plain string will do:
+
+    ```Ruby
+    # bad
+    if command[/quit/]
+      ...
+    end
+    
+    # good
+    if command['quit']
+      ...
+    end
+    ```
+  
 * For simple constructions you can use regexp directly through string index.
 
     ```Ruby
@@ -1307,33 +931,29 @@ syntax.
     string[/text (grp)/, 1] = 'replace'  # string => 'text replace'
     ```
 
-* Use non capturing groups when you don't use captured result of parenthesis.
-
-    ```Ruby
-    /(first|second)/   # bad
-    /(?:first|second)/ # good
-    ```
-
-* Avoid using $1-9 as it can be hard to track what they contain. Named groups
-  can be used instead.
+* Avoid using $1-9 as it can be hard to track what they contain and they live globally. Numbered indexes
+  or named groups can be used instead.
 
     ```Ruby
     # bad
-    /(regexp)/ =~ string
+    /\A(https?):/ =~ url
     ...
-    process $1
+    setup_connection($1)
+    
+    # good
+    protocol = url[/\A(https?):/, 1]
+    ...
+    setup_connection(protocol)
 
     # good
-    /(?<meaningful_var>regexp)/ =~ string
+    /\A(?<protocol>https?):/ =~ url
     ...
-    process meaningful_var
+    setup_connection(protocol)
     ```
 
-* Character classes have only few special characters you should care about:
-  `^`, `-`, `\`, `]`, so don't escape `.` or brackets in `[]`.
-
-* Be careful with `^` and `$` as they match start/end of line, not string endings.
-  If you want to match the whole string use: `\A` and `\z` (not to be
+* Be careful not to use `^` and `$` for anchors (like in other languages) because in
+  Ruby they also match newlines.
+  For anchors, use `\A` and `\z` (not to be
   confused with `\Z` which is the equivalent of `/\n?\z/`).
 
     ```Ruby
@@ -1342,8 +962,8 @@ syntax.
     string[/\Ausername\z/] # don't match
     ```
 
-* Use `x` modifier for complex regexps. This makes them more readable and you
-  can add some useful comments. Just be careful as spaces are ignored.
+* Use `x` modifier for complex regexps so that you can use whitespace and comments to
+  make them more readable. Just be careful as spaces are ignored.
 
     ```Ruby
     regexp = %r{
@@ -1355,18 +975,12 @@ syntax.
     }x
     ```
 
-* For complex replacements `sub`/`gsub` can be used with block or hash.
+* For complex replacements `sub`/`gsub` can be used with a block or hash.
 
 ## Percent Literals
 
-* Use `%w` freely.
-
-    ```Ruby
-    STATES = %w(draft open closed)
-    ```
-
 * Use `%()` for single-line strings which require both interpolation
-  and embedded double-quotes. For multi-line strings, prefer heredocs.
+  and embedded double-quotes. For multi-line strings, prefer << heredocs.
 
     ```Ruby
     # bad (no interpolation needed)
@@ -1385,28 +999,27 @@ syntax.
     %(<tr><td class="name">#{name}</td>)
     ```
 
-* Use `%r` only for regular expressions matching *more than* one '/' character.
-
-    ```Ruby
-    # bad
-    %r(\s+)
-
-    # still bad
-    %r(^/(.*)$)
-    # should be /^\/(.*)$/
-
-    # good
-    %r(^/blog/2011/(.*)$)
-    ```
-
 * Avoid `%q`, `%Q`, `%x`, `%s`, and `%W`.
 
 * Prefer `()` as delimiters for all `%` literals.
 
 ## Metaprogramming
 
-* Do not mess around in core classes when writing libraries. (Do not monkey
-patch them.)
+* Only use metaprogramming when necessary.  For example, `deliver_<mail_message>` in TMail was completely
+  unnecessary since it was equivalent to simply `deliver(:mail_message)`.
+
+* Do not monkey patch core classes unless you really need to change their behavior
+  generally across all code in the process including other gems and libraries (separation of concerns!):
+
+    ```ruby
+    # bad
+    class Fixnum
+      def days
+        ...
+      end
+    end
+    
+    ```
 
 * The block form of `class_eval` is preferable to the string-interpolated form.
   - when you use the string-interpolated form, always supply `__FILE__` and `__LINE__`, so that your backtraces make sense:
@@ -1415,7 +1028,7 @@ patch them.)
     class_eval 'def use_relative_model_naming?; true; end', __FILE__, __LINE__
     ```
 
-  - `define_method` is preferable to `class_eval{ def ... }`
+  - `define_method` is preferable to `class_eval { def ... }`
 
 * When using `class_eval` (or other `eval`) with string interpolation, add a comment block showing its appearance if interpolated (a practice I learned from the rails code):
 
@@ -1437,11 +1050,11 @@ patch them.)
     end
     ```
 
-* avoid using `method_missing` for metaprogramming. Backtraces become messy; the behavior is not listed in `#methods`; misspelled method calls might silently work (`nukes.launch_state = false`). Consider using delegation, proxy, or `define_method` instead.  If you must, use `method_missing`,
+* Avoid `method_missing` if possible. Backtraces become messy; the behavior is not listed in `#methods`; misspelled method calls might silently work (`nukes.launch_state = false`). Consider using delegation, proxy, or `define_method` instead.  If you must, use `method_missing`,
   - be sure to [also define `respond_to_missing?`](http://blog.marc-andre.ca/2010/11/methodmissing-politely.html)
   - only catch methods with a well-defined prefix, such as `find_by_*` -- make your code as assertive as possible.
   - call `super` at the end of your statement
-  - delegate to assertive, non-magical methods:
+  - delegate to a reusable, testable, non-magical method:
 
     ```ruby
     # bad
@@ -1462,57 +1075,18 @@ patch them.)
       end
     end
 
-    # best of all, though, would to define_method as each findable attribute is declared
+    # best of all, though, would be to define_method as each findable attribute is declared
     ```
 
 ## Misc
 
 * Write `ruby -w` safe code.
-* Avoid hashes as optional parameters. Does the method do too much?
-* Avoid methods longer than 10 LOC (lines of code). Ideally, most methods will be shorter than
-  5 LOC. Empty lines do not contribute to the relevant LOC.
-* Avoid parameter lists longer than three or four parameters.
-* If you really have to, add "global" methods to Kernel and make them private.
-* Use class instance variables instead of global variables.
-
-    ```Ruby
-    #bad
-    $foo_bar = 1
-
-    #good
-    class Foo
-      class << self
-        attr_accessor :bar
-      end
-    end
-
-    Foo.bar = 1
-    ```
-
+* Code in a functional way, avoiding mutation and other side-effects unless performance concerns require the side-effects.
+  Mutating arguments is a side-effect so don't do it unless that is the purpose of the method.
+* Don't put required parameters into options hashes.
+* Try to keep methods to 10 lines of code or less. Ideally, most methods will be shorter than
+  5 lines of code. Comments and empty lines do not count.
+* Try to keep parameter lists limited to three or four parameters.
 * Avoid `alias` when `alias_method` will do.
 * Use `OptionParser` for parsing complex command line options and
 `ruby -s` for trivial command line options.
-* Code in a functional way, avoiding mutation when that makes sense.
-* Avoid needless metaprogramming.
-* Do not mutate arguments unless that is the purpose of the method.
-* Avoid more than three levels of block nesting.
-* Be consistent. In an ideal world, be consistent with these guidelines.
-* Use common sense.
-
-# Contributing
-
-Nothing written in this guide is set in stone. It's my desire to work
-together with everyone interested in Ruby coding style, so that we could
-ultimately create a resource that will be beneficial to the entire Ruby
-community.
-
-Feel free to open tickets or send pull requests with improvements. Thanks in
-advance for your help!
-
-# Spread the Word
-
-A community-driven style guide is of little use to a community that
-doesn't know about its existence. Tweet about the guide, share it with
-your friends and colleagues. Every comment, suggestion or opinion we
-get makes the guide just a little bit better. And we want to have the
-best possible guide, don't we?

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 
 ## Source Code Layout
 
-### Use two **spaces** per indentation level. No hard tabs.
+### Use two **spaces** per indentation level. No hard tabs.  
 
     ```Ruby
     # good

--- a/README.md
+++ b/README.md
@@ -581,8 +581,8 @@ More details [here](http://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Method_
 
 ```ruby
 # bad
-lambda = lambda { |a, b| a + b }
-lambda.call(1, 2)
+lam = lambda { |a, b| a + b }
+lam.call(1, 2)
 
 # good
 lambda = ->(a, b) { a + b }
@@ -681,7 +681,7 @@ class SomeClass
 end
 ```
 
-### Use `def self.method` to define singleton methods so you don't have to repeat the class name (Don't Repeat Yourself).
+### Use `class << self` or `def self.method` to define singleton methods so you don't have to repeat the class name (Don't Repeat Yourself).
 
 ```ruby
 class TestClass
@@ -695,13 +695,16 @@ class TestClass
     ...
   end
 
-  # Also possible and convenient when you
-  # have to define many singleton methods.
+  # best
+  # this form lets you define many class methods,
+  # and public/private
+  # and attr_reader work as expected.
   class << self
     def first_method
       ...
     end
 
+    private:
     def second_method_etc
       ...
     end

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 
 ### Use two **spaces** per indentation level. No hard tabs.  
 
-    ```Ruby
+```ruby
     # good
     def some_method
       do_something
@@ -30,7 +30,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     def some_method
         do_something
     end
-    ```
+```
 
 ### Use spaces around operators and `=>`, after commas, colons and semicolons, around `{`
   and before `}`.  (But there is no need for spaces inside the empty hash `{}`.)

--- a/README.md
+++ b/README.md
@@ -595,7 +595,7 @@ result = hash.map { |_, v| v + 1 }
 
 ### Use `snake_case` for methods and variables.
 
-### Use `CamelCase` for classes and modules.  (Keep acronyms like HTTP, RFC, XML uppercase.)
+### Use `CamelCase` for classes and modules. Keep acronyms like HTTP, RFC, XML uppercase when possible. (Upper case words cause problems for rails routes.)
 
 ### Use `SCREAMING_SNAKE_CASE` for other constants.
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
   
 * Avoid multi-line `?:` (the ternary operator); use `if/unless` instead.
 
-* Only use trailing `if/unless` when they are are rare footnotes that can be
+* Only use trailing `if/unless` when they are rare footnotes that can be
   ignored in the usual, "go-right" case.  That is, the statement you start with should
   almost always execute.
   (A good alternative for assertions and other one-line code that rarely executes is control-flow `and/or`.)

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ end.map { |name| name.upcase }
 ```
 
 Some will argue that multiline chaining would look OK with the use of {...}, but they should
-ask themselves - it this code really readable and can't the blocks contents be extracted into
+ask themselves: is this code really readable and can't the blocks contents be extracted into
 nifty methods?
 
 ### Avoid `return` where not needed for flow of control.

--- a/README.md
+++ b/README.md
@@ -35,37 +35,37 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 ### Use spaces around operators and `=>`, after commas, colons and semicolons, around `{`
   and before `}`.  (But there is no need for spaces inside the empty hash `{}`.)
 
-    ```Ruby
+```ruby
     a, b = 1, 2 + 3
     location = { :city => 'Santa Barbara', :state => 'CA' }
     size > 10 ? 'large' : 'small'
     [1, 2, 3].each { |e| puts e }
     params = {}
-    ```
+```
 
     The only exception is when using the exponent operator:
 
-    ```Ruby
+```ruby
     # bad
     e = M * c ** 2
 
     # good
     e = M * c**2
-    ```
+```
 
 ### No spaces after `(`, `[` or before `]`, `)`.
 
-    ```Ruby
+```ruby
     some(arg).other
     [1, 2, 3].length
     collection = []
-    ```
+```
 
 ### Indent `when` as deep as `case`. I know that many would disagree
   with this one, but it's the style established in both the "The Ruby
   Programming Language" and "Programming Ruby".
 
-    ```Ruby
+```ruby
     case
     when song.name == 'Misty'
       puts 'Not again!'
@@ -85,12 +85,12 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
            when 1940..1950 then 'Bebop'
            else 'Jazz'
            end
-    ```
+```
 
 ### Use empty lines between `def`s and to break up a method into logical
   paragraphs.
 
-    ```Ruby
+```ruby
     def some_method
       data = initialize(options)
 
@@ -102,11 +102,11 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     def some_method
       result
     end
-    ```
+```
 
 ### Align the parameters of a method call if they span over multiple lines using normal indent.
 
-    ```Ruby
+```ruby
     # starting point (line is too long)
     def send_mail(source)
       Mailer.deliver(to: 'bob@example.com', from: 'us@example.com', subject: 'Important message', body: source.text)
@@ -137,7 +137,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
                      subject: 'Important message',
                      body: source.text)
     end
-    ```
+```
 
 ### Use RDoc and its conventions for API documentation.  Don't put an
   empty line between the comment block and the `def`.
@@ -150,7 +150,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 ### Prefer parentheses around arguments in method declaration.  Omit the
   parentheses when the method doesn't accept any arguments.
 
-     ```Ruby
+ ```ruby
      def some_method
        ...
      end
@@ -158,7 +158,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
      def some_method_with_arguments(arg1, arg2)
        ...
      end
-     ```
+ ```
 
 ### Never use `for`, unless you know exactly why. Most of the time iterators
   should be used instead. `for` is implemented in terms of `each` (so
@@ -166,7 +166,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
   doesn't introduce a new scope (unlike `each`) and variables defined
   in its block will be visible outside it.
 
-    ```Ruby
+```ruby
     arr = [1, 2, 3]
 
     # bad
@@ -176,11 +176,11 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 
     # good
     arr.each { |elem| puts elem }
-    ```
+```
 
 ### Never use `then` for multi-line `if/unless`.
 
-    ```Ruby
+```ruby
     # bad
     if some_condition then
       ...
@@ -190,14 +190,14 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     if some_condition
       ...
     end
-    ```
+```
 
 ### Use one expression per branch in a ternary operator. This
   also means that ternary operators must not be nested. Prefer
   `if/else` constructs in these cases.
   Avoid multi-line ternary; use `if/unless` instead.
 
-    ```Ruby
+```ruby
     # bad
     some_condition ? (nested_condition ? nested_something : nested_something_else) : something_else
 
@@ -207,25 +207,25 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     else
       something_else
     end
-    ```
+```
 
 ### Never use `if x: ...` - it is removed in Ruby 1.9. Use multi-line if or
   the ternary operator instead.
 
-    ```Ruby
+```ruby
     # bad
     result = if some_condition: something else something_else end
 
     # good
     result = some_condition ? something : something_else
-    ```
+```
 
 ### Use `when x then ...` for one-line cases. The alternative syntax
   `when x: ...` is removed in Ruby 1.9.
 
 ### Use `&&/||` for boolean expressions, `and/or` for control flow.
 
-    ```Ruby
+```ruby
     # boolean expression
     if document.text_changed? || document.settings_changed?
       document.save!
@@ -233,24 +233,24 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 
     # control flow
     document.saved? or document.save!
-    ```
+```
 
   Beware: `and/or` have lower precedence than `=`!
   
-    ```Ruby
+```ruby
     flag = top_of_page? or reset_page
     
     # is equivalent to
     (flag = top_of_page?) or reset_page
     
-    ```
+```
 
 ### Only use trailing `if/unless` when they are rare footnotes that can be
   ignored in the usual, "go-right" case.  That is, the statement you start with should
   almost always execute.
   (A good alternative for assertions and other one-line code that rarely executes is control-flow `and/or`.)
 
-    ```Ruby
+```ruby
     # bad -- the raise rarely executes
     raise ArgumentError, "name must be provided" unless name.present?
 
@@ -262,12 +262,12 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     
     # good -- the if is almost always true
     send_notification(users) if users.any?
-    ```
+```
 
 ### Favor `unless` over `if` for negative conditions (or use control
   flow `or`).
 
-    ```Ruby
+```ruby
     # bad
     do_something if !some_condition
 
@@ -276,11 +276,11 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 
     # another good option
     some_condition or do_something
-    ```
+```
 
 ### Never use `unless` with `else`. Rewrite these with the positive case first.
 
-    ```Ruby
+```ruby
     # bad
     unless success?
       puts 'failure'
@@ -294,13 +294,13 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     else
       puts 'failure'
     end
-    ```
+```
 
 ### Don't use parentheses around the condition of an `if/unless/while`,
   unless the condition contains an assignment (see "Using the return
   value of `=`" below).
 
-    ```Ruby
+```ruby
     # bad
     if (x > 10)
       ...
@@ -315,12 +315,12 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     if (x = self.next_value)
       ...
     end
-    ```
+```
 
 ### Favor modifier `while/until` usage when you have a single-line
   body.
 
-    ```Ruby
+```ruby
     # bad
     while some_condition
       do_something
@@ -328,17 +328,17 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 
     # good
     do_something while some_condition
-    ```
+```
 
 ### Favor `until` over `while` for negative conditions.
 
-    ```Ruby
+```ruby
     # bad
     do_something while !some_condition
 
     # good
     do_something until some_condition
-    ```
+```
 
 ### Omit parentheses around parameters for methods that are part of an
   internal DSL (e.g. Rake, Rails, RSpec), methods that are with
@@ -346,7 +346,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
   access methods. It is preferred to use parentheses around the arguments of all other
   method invocations.
 
-    ```Ruby
+```ruby
     class Person
       attr_reader :name, :age
 
@@ -360,7 +360,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 
     x = Math.sin(y)
     array.delete(e)
-    ```
+```
 
 ### Prefer `{...}` over `do...end` for single-line blocks.  Avoid using
   `{...}` for multi-line blocks (multiline chaining is always
@@ -368,7 +368,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
   definitions" (e.g. in Rakefiles and certain DSLs).  Avoid `do...end`
   when chaining.
 
-    ```Ruby
+```ruby
     names = ['Bozhidar', 'Steve', 'Sarah']
 
     # good
@@ -386,7 +386,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     names.select do |name|
       name.start_with?('S')
     end.map { |name| name.upcase }
-    ```
+```
 
     Some will argue that multiline chaining would look OK with the use of {...}, but they should
     ask themselves - it this code really readable and can't the blocks contents be extracted into
@@ -395,7 +395,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 ### Avoid `return` where not needed for flow of control.
   (Omitting `return` is more succinct and declarative, and your code will still work if you refactor it into a block later.)
 
-    ```Ruby
+```ruby
     # bad
     def some_method(some_arr)
       return some_arr.size
@@ -405,11 +405,11 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     def some_method(some_arr)
       some_arr.size
     end
-    ```
+```
 
 ### Only use `self` when required for calling a self write accessor.
 
-    ```Ruby
+```ruby
     # bad
     def ready?
       if self.last_reviewed_at > self.last_updated_at
@@ -427,11 +427,11 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
       end
       status == :verified
     end
-    ```
+```
 
 ### As a corollary, avoid shadowing methods with local variables unless they are both equivalent
 
-    ```Ruby
+```ruby
     class Foo
       attr_accessor :options
 
@@ -458,7 +458,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 
 ### Use spaces around the `=` operator when assigning default values to method parameters:
 
-    ```Ruby
+```Ruby
     # bad
     def some_method(arg1=:default, arg2=nil, arg3=[])
       # do something...
@@ -475,7 +475,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 
 ### Avoid line continuation (\\) unless absolutely required.
 
-    ```Ruby
+```ruby
     # bad
     result = 1 \
              - 2
@@ -483,12 +483,12 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     # better
     result = 1 -
              2
-    ```
+```
 
 ### Using the return value of `=` (an assignment) is ok, but surround the
   assignment with parentheses to it clear you are not mistakenly using `=` when you meant `==`.
 
-    ```Ruby
+```ruby
     # good - shows intended use of assignment
     if (v = array.grep(/foo/)) ...
 
@@ -497,47 +497,47 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 
     # also good - shows intended use of assignment and has correct precedence.
     if (v = next_value) == 'hello' ...
-    ```
+```
 
 ### Don't use `||=` to initialize boolean variables. (Consider what
 would happen if the current value happened to be `false`.)
 
-    ```Ruby
+```ruby
     # bad - would set enabled to true even if it was false
     enabled ||= true
 
     # good
     enabled = true if enabled.nil?
-    ```
+```
 
 ### Avoid using Perl-style special variables (like `$0-9`, `$``,
   etc. ). They are cryptic and global.
 
 ### Never put a space between a method name and the opening parenthesis.
 
-    ```Ruby
+```ruby
     # bad
     f (3 + 2) + 1
 
     # good
     f(3 + 2) + 1
-    ```
+```
 
 ### Ruby 1.9 hash literal syntax is preferred when the hash keys are symbols.
 
-    ```Ruby
+```ruby
     # bad
     hash = { :one => 1, :two => 2 }
 
     # good
     hash = { one: 1, two: 2 }
-    ```
+```
 
 ### `lambda` is preferred over `proc`/`Proc.new`. This is because `lambda`s enforce argument list cardinality and have unsurprising `return` semantics. (Only use `proc` if you really need a return statement that returns from the enclosing code.)  More details [here](http://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Method_Calls#Understanding_blocks.2C_Procs_and_methods).
 
 ### Ruby 1.9 `lambda` literal syntax is preferred.
 
-    ```Ruby
+```ruby
     # bad
     lambda = lambda { |a, b| a + b }
     lambda.call(1, 2)
@@ -545,17 +545,17 @@ would happen if the current value happened to be `false`.)
     # good
     lambda = ->(a, b) { a + b }
     lambda.(1, 2)
-    ```
+```
 
 ### Use `_` for unused block parameters.
 
-    ```Ruby
+```ruby
     # bad
     result = hash.map { |k, v| v + 1 }
 
     # good
     result = hash.map { |_, v| v + 1 }
-    ```
+```
 
 ## Naming
 
@@ -603,7 +603,7 @@ would happen if the current value happened to be `false`.)
 ### Use @ class variables when you want separate values per subclass.
   Use @@ variables when you want process-wide globals (such as for a process-wide cache).
 
-    ```Ruby
+```ruby
     class Parent
       @@class_var = 'parent'
 
@@ -617,7 +617,7 @@ would happen if the current value happened to be `false`.)
     end
 
     Parent.print_class_var # => will print "child"
-    ```
+```
 
     As you can see all the classes in a class hierarchy actually share one
     class variable. Class instance variables should usually be preferred
@@ -629,7 +629,7 @@ in accordance with their intended usage.
 ### Indent the `public`, `protected`, and `private` methods as much the
   method definitions they apply to. Leave one blank line above them.
 
-    ```Ruby
+```ruby
     class SomeClass
       def public_method
         ...
@@ -643,7 +643,7 @@ in accordance with their intended usage.
 
 ### Use `def self.method` to define singleton methods so you don't have to repeat the class name (Don't Repeat Yourself).
 
-    ```Ruby
+```Ruby
     class TestClass
       # bad
       def TestClass.some_method
@@ -677,7 +677,7 @@ in accordance with their intended usage.
   exception had been raised at all. In effect, the exception will be
   silently thrown away.
 
-    ```Ruby
+```ruby
     def foo
       begin
         fail
@@ -685,11 +685,11 @@ in accordance with their intended usage.
         return 'very bad idea'
       end
     end
-    ```
+```
 
 ### Use *implicit begin blocks* when possible.
 
-    ```Ruby
+```ruby
     # bad
     def foo
       begin
@@ -705,12 +705,12 @@ in accordance with their intended usage.
     rescue
       # failure handling goes here
     end
-    ```
+```
 
 ### Mitigate the proliferation of `begin` blocks by using
   *contingency methods* (a term coined by Avdi Grimm).
 
-    ```Ruby
+```ruby
     # bad
     begin
       something_that_might_fail
@@ -734,11 +734,11 @@ in accordance with their intended usage.
     with_io_error_handling { something_that_might_fail }
 
     with_io_error_handling { something_else_that_might_fail }
-    ```
+```
 
 ### Don't suppress exceptions.
 
-    ```Ruby
+```ruby
     # bad
     begin
       # an exception occurs here
@@ -748,11 +748,11 @@ in accordance with their intended usage.
 
     # bad
     do_something rescue nil
-    ```
+```
 
 ### Don't use exceptions for flow of control.
 
-    ```Ruby
+```ruby
     # bad
     begin
       n / d
@@ -766,12 +766,12 @@ in accordance with their intended usage.
     else
       n / d
     end
-    ```
+```
 
 ### Avoid rescuing the `Exception` class.  This will trap signals and calls to
   `exit`, requiring you to `kill -9` the process.
 
-    ```Ruby
+```ruby
     # bad
     begin
       # calls to exit and kill signals will be caught (except kill -9)
@@ -797,12 +797,12 @@ in accordance with their intended usage.
       # exception handling
     end
 
-    ```
+```
 
 ### Put more specific exceptions higher up the rescue chain, otherwise
   they'll never be rescued from.
 
-    ```Ruby
+```ruby
     # bad
     begin
       # some code
@@ -820,12 +820,12 @@ in accordance with their intended usage.
     rescue Exception => e
       # some handling
     end
-    ```
+```
 
 ### Release external resources obtained by your program in an ensure
 block.
 
-    ```Ruby
+```ruby
     f = File.open('testfile')
     begin
       # .. process
@@ -834,7 +834,7 @@ block.
     ensure
       f.close unless f.nil?
     end
-    ```
+```
 
 ### Use exceptions from the standard library for simple cases so you can avoid
 introducing new exception classes.
@@ -855,25 +855,25 @@ introducing new exception classes.
 
 ### Prefer string interpolation instead of string concatenation:
 
-    ```Ruby
+```ruby
     # bad
     email_with_name = user.name + ' <' + user.email + '>'
 
     # good
     email_with_name = "#{user.name} <#{user.email}>"
-    ```
+```
 
 ### Consider padding string interpolation code with space. It more clearly sets the
   code apart from the string.
 
-    ```Ruby
+```ruby
     "#{ user.last_name }, #{ user.first_name }"
-    ```
+```
 
 ### `String#<<` performs better by mutating the string in place.  `String#+`, avoids mutation (which is good
   in a functional way) but therefore runs slower since it creates a new string object.
 
-    ```Ruby
+```ruby
     # faster
     html = ''
 
@@ -892,13 +892,13 @@ introducing new exception classes.
     html = paragraphs.map do |paragraph|
       "<p>#{paragraph}</p>"
     end.join
-    ```
+```
 
 ## Regular Expressions
 
 ### Don't use a regular expression when a plain string will do:
 
-    ```Ruby
+```ruby
     # bad
     if command[/quit/]
       ...
@@ -908,20 +908,20 @@ introducing new exception classes.
     if command['quit']
       ...
     end
-    ```
+```
   
 ### For simple constructions you can use regexp directly through string index.
 
-    ```Ruby
+```ruby
     match = string[/regexp/]             # get content of matched regexp
     first_group = string[/text(grp)/, 1] # get content of captured group
     string[/text (grp)/, 1] = 'replace'  # string => 'text replace'
-    ```
+```
 
 ### Avoid using $1-9 as it can be hard to track what they contain and they live globally. Numbered indexes
   or named groups can be used instead.
 
-    ```Ruby
+```ruby
     # bad
     /\A(https?):/ =~ url
     ...
@@ -936,23 +936,23 @@ introducing new exception classes.
     /\A(?<protocol>https?):/ =~ url
     ...
     setup_connection(protocol)
-    ```
+```
 
 ### Be careful not to use `^` and `$` for anchors (like in other languages) because in
   Ruby they also match newlines.
   For anchors, use `\A` and `\z` (not to be
   confused with `\Z` which is the equivalent of `/\n?\z/`).
 
-    ```Ruby
+```ruby
     string = "some injection\nusername"
     string[/^username$/]   # matches
     string[/\Ausername\z/] # don't match
-    ```
+```
 
 ### Use `x` modifier for complex regexps so that you can use whitespace and comments to
   make them more readable. Just be careful as spaces are ignored.
 
-    ```Ruby
+```ruby
     regexp = %r{
       start         # some text
       \s            # white space char
@@ -960,7 +960,7 @@ introducing new exception classes.
       (?:alt1|alt2) # some alternation
       end
     }x
-    ```
+```
 
 ### For complex replacements `sub`/`gsub` can be used with a block or hash.
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     ```
 
 * Use spaces around operators and `=>`, after commas, colons and semicolons, around `{`
-  and before `}`.
+  and before `}`.  (But there is no need for spaces inside the empty hash `{}`.)
 
     ```Ruby
     a, b = 1, 2 + 3
     location = { :city => 'Santa Barbara', :state => 'CA' }
     size > 10 ? 'large' : 'small'
     [1, 2, 3].each { |e| puts e }
+    params = {}
     ```
 
     The only exception is when using the exponent operator:
@@ -57,6 +58,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     ```Ruby
     some(arg).other
     [1, 2, 3].length
+    collection = []
     ```
 
 * Indent `when` as deep as `case`. I know that many would disagree

--- a/README.md
+++ b/README.md
@@ -574,6 +574,12 @@ would happen if the current value happened to be `false`.)
   * `select` over `find_all`
   * `size` over `length`
 
+* Company names with capitals in the middle (e.g. RingRevenue) should drop the inner capitalization so that rails string helpers don't insert underscores in the middle
+  Examples:
+  * RingRevenue: Constantize: Ringrevenue, underscored: ringrevenue
+  * HubSpot     => Hubspot hubspot
+  * HubspotIntegration => hubspot_integration
+
 ## Comments
 
 > Good code is its own best documentation. As you're about to add a

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 
 ## Syntax
 
-* Use `def` with parentheses when there are arguments. Omit the
+* Prefer parentheses around arguments in method declaration.  Omit the
   parentheses when the method doesn't accept any arguments.
 
      ```Ruby
@@ -343,7 +343,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 * Omit parentheses around parameters for methods that are part of an
   internal DSL (e.g. Rake, Rails, RSpec), methods that are with
   "keyword" status in Ruby (e.g. `attr_reader`, `puts`) and attribute
-  access methods. Use parentheses around the arguments of all other
+  access methods. It is preferred to use parentheses around the arguments of all other
   method invocations.
 
     ```Ruby
@@ -393,7 +393,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     nifty methods?
 
 * Avoid `return` where not needed for flow of control.
-  Omitting `return` is more succinct and declarative, and your code will still work if you refactor it into a block later.
+  (Omitting `return` is more succinct and declarative, and your code will still work if you refactor it into a block later.)
 
     ```Ruby
     # bad

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ Some will argue that multiline chaining would look OK with the use of {...}, but
 ask themselves: is this code really readable and can't the blocks contents be extracted into
 nifty methods?
 
-### Avoid `return` where not needed for flow of control.
+### Avoid `return` where not needed for flow of control. Prefer `if`/`else` or `&&`/`||`.
 (Omitting `return` is more succinct and declarative, and your code will still work if you refactor it into a block later.)
 
 ```ruby
@@ -402,6 +402,46 @@ end
 # good
 def some_method(some_arr)
   some_arr.size
+end
+
+# bad
+def click_url
+  return "http://#{click_domain}/c" if click_domain.nonblank?
+  return click_url_for_hostname(vanity_domain) if vanity_domain.nonblank?
+  click_url_for_hostname(CLICK_URL_DEFAULT_DOMAIN)
+end
+
+# good
+def click_url
+  if click_domain.nonblank?
+    "http://#{click_domain}/c"
+  elsif vanity_domain.nonblank?
+    click_url_for_hostname(vanity_domain)
+  else
+    click_url_for_hostname(CLICK_URL_DEFAULT_DOMAIN)
+  end
+end
+
+# bad
+def should_redirect?
+  return false unless rendered?
+  return true if redirect_location.nonblank?
+  return true if global_redirect?
+  return false
+end
+
+# good
+def should_redirect?
+  !rendered && (redirect_location.nonblank? || global_redirect?)
+end
+
+# better still
+def have_redirect?
+  redirect_location.nonblank? || global_redirect?
+end
+
+def should_redirect?
+  !rendered && have_redirect?
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ result = 1 -
 ```
 
 ### Using the return value of `=` (an assignment) is ok
-But surround the assignment with parentheses to it clear you are not mistakenly using `=` when you meant `==`.
+But surround the assignment with parentheses to make it clear you are not mistakenly using `=` when you meant `==`.
 
 ```ruby
 # good - shows intended use of assignment

--- a/README.md
+++ b/README.md
@@ -577,8 +577,8 @@ lam = lambda { |a, b| a + (b || 0) }
 lam.call(1, 2)
 
 # good
-lambda = ->(a, b = 0) { a + b }
-lambda.call(1, 2)
+lam = ->(a, b = 0) { a + b }
+lam.call(1, 2)
 ```
 
 ### Use `_` for unused block parameters.

--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ would happen if the current value happened to be `false`.)
 * Use `SCREAMING_SNAKE_CASE` for other constants.
 * The names of predicate methods (methods that return a boolean value)
   should end in a question mark.
-  (i.e. `Array#empty?`).
+  (e.g. `Array#empty?`).
 * The names of potentially "dangerous" or surprising methods (e.g. methods that have side-effects like mutating a variable
   or changing the process flow) should end with an exclamation mark.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 
 ## Source Code Layout
 
-### Use two **spaces** per indentation level. No hard tabs.  
+### Use two **spaces** per indentation level. No hard tabs.
 
 ```ruby
 # good
@@ -87,8 +87,7 @@ kind = case year
        end
 ```
 
-### Use empty lines between `def`s and to break up a method into logical
-  paragraphs.
+### Use empty lines between `def`s and to break up a method into logical paragraphs.
 
 ```ruby
 def some_method
@@ -139,18 +138,21 @@ def send_mail(source)
 end
 ```
 
-### Use RDoc and its conventions for API documentation.  Don't put an
-  empty line between the comment block and the `def`.
+### Use RDoc and its conventions for API documentation.
+  Don't put an empty line between the comment block and the `def`.
+
 ### Avoid lines longer than 120 characters.
+
 ### Avoid trailing whitespace.
+
 ### Use `UTF-8` as the source file encoding when you need more than plain ASCII.
 
 ## Syntax
 
-### Prefer parentheses around arguments in method declaration.  Omit the
-  parentheses when the method doesn't accept any arguments.
+### Prefer parentheses around arguments in method declaration.
+ Omit the parentheses when the method doesn't accept any arguments.
 
- ```ruby
+```ruby
 def some_method
   ...
 end
@@ -158,13 +160,13 @@ end
 def some_method_with_arguments(arg1, arg2)
   ...
 end
- ```
+```
 
-### Never use `for`, unless you know exactly why. Most of the time iterators
-  should be used instead. `for` is implemented in terms of `each` (so
-  you're adding a level of indirection), but with a twist - `for`
-  doesn't introduce a new scope (unlike `each`) and variables defined
-  in its block will be visible outside it.
+### Never use `for`, unless you know exactly why.
+Most of the time iterators should be used instead. `for` is implemented in terms of `each` (so
+you're adding a level of indirection), but with a twist - `for`
+doesn't introduce a new scope (unlike `each`) and variables defined
+in its block will be visible outside it.
 
 ```ruby
 arr = [1, 2, 3]
@@ -192,10 +194,10 @@ if some_condition
 end
 ```
 
-### Use one expression per branch in a ternary operator. This
-  also means that ternary operators must not be nested. Prefer
-  `if/else` constructs in these cases.
-  Avoid multi-line ternary; use `if/unless` instead.
+### Use one expression per branch in a ternary operator.
+This also means that ternary operators must not be nested. Prefer
+`if/else` constructs in these cases.
+Avoid multi-line ternary; use `if/unless` instead.
 
 ```ruby
 # bad
@@ -209,8 +211,8 @@ else
 end
 ```
 
-### Never use `if x: ...` - it is removed in Ruby 1.9. Use multi-line if or
-  the ternary operator instead.
+### Never use `if x: ...` - it is removed in Ruby 1.9.
+Use multi-line if or the ternary operator instead.
 
 ```ruby
 # bad
@@ -220,8 +222,8 @@ result = if some_condition: something else something_else end
 result = some_condition ? something : something_else
 ```
 
-### Use `when x then ...` for one-line cases. The alternative syntax
-  `when x: ...` is removed in Ruby 1.9.
+### Use `when x then ...` for one-line cases.
+The alternative syntax `when x: ...` is removed in Ruby 1.9.
 
 ### Use `&&/||` for boolean expressions, `and/or` for control flow.
 
@@ -235,7 +237,7 @@ end
 document.saved? or document.save!
 ```
 
-  Beware: `and/or` have lower precedence than `=`!
+Beware: `and/or` have lower precedence than `=`!
 
 ```ruby
 flag = top_of_page? or reset_page
@@ -245,9 +247,8 @@ flag = top_of_page? or reset_page
 
 ```
 
-### Only use trailing `if/unless` when they are rare footnotes that can be
-  ignored in the usual, "go-right" case.  That is, the statement you start with should
-  almost always execute.
+### Only use trailing `if/unless` when they are rare footnotes that can be ignored in the usual, "go-right" case.
+That is, the statement you start with should almost always execute.
   (A good alternative for assertions and other one-line code that rarely executes is control-flow `and/or`.)
 
 ```ruby
@@ -264,8 +265,7 @@ formt(page) unless page.already_formatted?
 send_notification(users) if users.any?
 ```
 
-### Favor `unless` over `if` for negative conditions (or use control
-  flow `or`).
+### Favor `unless` over `if` for negative conditions (or use control flow `or`).
 
 ```ruby
 # bad
@@ -296,9 +296,8 @@ else
 end
 ```
 
-### Don't use parentheses around the condition of an `if/unless/while`,
-  unless the condition contains an assignment (see "Using the return
-  value of `=`" below).
+### Don't use parentheses around the condition of an `if/unless/while`, unless the condition contains an assignment.
+(see "Using the return value of `=`" below).
 
 ```ruby
 # bad
@@ -317,8 +316,7 @@ if (x = self.next_value)
 end
 ```
 
-### Favor modifier `while/until` usage when you have a single-line
-  body.
+### Favor modifier `while/until` usage when you have a single-line body.
 
 ```ruby
 # bad
@@ -340,11 +338,11 @@ do_something while !some_condition
 do_something until some_condition
 ```
 
-### Omit parentheses around parameters for methods that are part of an
-  internal DSL (e.g. Rake, Rails, RSpec), methods that are with
-  "keyword" status in Ruby (e.g. `attr_reader`, `puts`) and attribute
-  access methods. It is preferred to use parentheses around the arguments of all other
-  method invocations.
+### Omit parentheses around parameters for methods that are part of an internal DSL
+(e.g. Rake, Rails, RSpec), methods that are with
+"keyword" status in Ruby (e.g. `attr_reader`, `puts`) and attribute
+access methods. It is preferred to use parentheses around the arguments of all other
+method invocations.
 
 ```ruby
 class Person
@@ -363,10 +361,10 @@ array.delete(e)
 ```
 
 ### Prefer `{...}` over `do...end` for single-line blocks.  Avoid using
-  `{...}` for multi-line blocks (multiline chaining is always
-  ugly). Always use `do...end` for "control flow" and "method
-  definitions" (e.g. in Rakefiles and certain DSLs).  Avoid `do...end`
-  when chaining.
+`{...}` for multi-line blocks (multiline chaining is always
+ugly). Always use `do...end` for "control flow" and "method
+definitions" (e.g. in Rakefiles and certain DSLs).  Avoid `do...end`
+when chaining.
 
 ```ruby
 names = ['Bozhidar', 'Steve', 'Sarah']
@@ -393,7 +391,7 @@ ask themselves - it this code really readable and can't the blocks contents be e
 nifty methods?
 
 ### Avoid `return` where not needed for flow of control.
-  (Omitting `return` is more succinct and declarative, and your code will still work if you refactor it into a block later.)
+(Omitting `return` is more succinct and declarative, and your code will still work if you refactor it into a block later.)
 
 ```ruby
 # bad
@@ -486,8 +484,8 @@ result = 1 -
          2
 ```
 
-### Using the return value of `=` (an assignment) is ok, but surround the
-  assignment with parentheses to it clear you are not mistakenly using `=` when you meant `==`.
+### Using the return value of `=` (an assignment) is ok
+But surround the assignment with parentheses to it clear you are not mistakenly using `=` when you meant `==`.
 
 ```ruby
 # good - shows intended use of assignment
@@ -500,8 +498,8 @@ if v = array.grep(/foo/) ...
 if (v = next_value) == 'hello' ...
 ```
 
-### Don't use `||=` to initialize boolean variables. (Consider what
-would happen if the current value happened to be `false`.)
+### Don't use `||=` to initialize boolean variables.
+(Consider what would happen if the current value happened to be `false`.)
 
 ```ruby
 # bad - would set enabled to true even if it was false
@@ -511,8 +509,8 @@ enabled ||= true
 enabled = true if enabled.nil?
 ```
 
-### Avoid using Perl-style special variables (like `$0-9`, `$``,
-  etc. ). They are cryptic and global.
+### Avoid using Perl-style special variables (like `$0-9`, `$``, etc. ).
+They are cryptic and global.
 
 ### Never put a space between a method name and the opening parenthesis.
 
@@ -534,7 +532,10 @@ hash = { :one => 1, :two => 2 }
 hash = { one: 1, two: 2 }
 ```
 
-### `lambda` is preferred over `proc`/`Proc.new`. This is because `lambda`s enforce argument list cardinality and have unsurprising `return` semantics. (Only use `proc` if you really need a return statement that returns from the enclosing code.)  More details [here](http://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Method_Calls#Understanding_blocks.2C_Procs_and_methods).
+### `lambda` is preferred over `proc`/`Proc.new`.
+This is because `lambda`s enforce argument list cardinality and have unsurprising `return` semantics.
+(Only use `proc` if you really need a return statement that returns from the enclosing code.)
+More details [here](http://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Method_Calls#Understanding_blocks.2C_Procs_and_methods).
 
 ### Ruby 1.9 `lambda` literal syntax is preferred.
 
@@ -561,14 +562,16 @@ result = hash.map { |_, v| v + 1 }
 ## Naming
 
 ### Use `snake_case` for methods and variables.
-### Use `CamelCase` for classes and modules.  (Keep acronyms like HTTP,
-  RFC, XML uppercase.)
+
+### Use `CamelCase` for classes and modules.  (Keep acronyms like HTTP, RFC, XML uppercase.)
+
 ### Use `SCREAMING_SNAKE_CASE` for other constants.
-### The names of predicate methods (methods that return a boolean value)
-  should end in a question mark.
-  (e.g. `Array#empty?`).
-### The names of potentially "dangerous" or surprising methods (e.g. methods that have side-effects like mutating a variable
-  or changing the process flow) should end with an exclamation mark.
+
+### The names of predicate methods (methods that return a boolean value) should end in a question mark.
+  (e.g. `Array#empty?`)
+
+### The names of potentially "dangerous" or surprising methods should end in an exclamation mark!
+(e.g. methods that have side-effects like mutating a variable or changing the process flow)
 
 ### Prefer
   * `map` over `collect`
@@ -578,10 +581,10 @@ result = hash.map { |_, v| v + 1 }
   * `size` over `length`
 
 ### Company names with capitals in the middle (e.g. RingRevenue) should drop the inner capitalization so that rails string helpers don't insert underscores in the middle
-  Examples:
-  * RingRevenue: Constantize: Ringrevenue, underscored: ringrevenue
-  * HubSpot     => Hubspot hubspot
-  * HubspotIntegration => hubspot_integration
+Examples:
+* RingRevenue: Constantize: Ringrevenue, underscored: ringrevenue
+* HubSpot     => Hubspot hubspot
+* HubspotIntegration => hubspot_integration
 
 ## Comments
 
@@ -596,13 +599,10 @@ result = hash.map { |_, v| v + 1 }
 
 ## Classes
 
-### Try to make your classes as
-  [SOLID](http://en.wikipedia.org/wiki/SOLID_(object-oriented_design\))
-  as possible.
-
+### Try to make your classes as [SOLID](http://en.wikipedia.org/wiki/SOLID_(object-oriented_design\)) as possible.
 
 ### Use @ class variables when you want separate values per subclass.
-  Use @@ variables when you want process-wide globals (such as for a process-wide cache).
+Use @@ variables when you want process-wide globals (such as for a process-wide cache).
 
 ```ruby
 class Parent
@@ -624,11 +624,9 @@ As you can see all the classes in a class hierarchy actually share one
 class variable. Class instance variables should usually be preferred
 over class variables.
 
-### Assign proper visibility levels to methods (`private`, `protected`)
-in accordance with their intended usage.
+### Assign proper visibility levels to methods (`private`, `protected`) in accordance with their intended usage.
 
-### Indent the `public`, `protected`, and `private` methods as much the
-  method definitions they apply to. Leave one blank line above them.
+### Indent the `public`, `protected`, and `private` methods as much the method definitions they apply to. Leave one blank line above them.
 
 ```ruby
 class SomeClass
@@ -673,11 +671,12 @@ end
 
 ## Exceptions
 
-### Never return from an `ensure` block. If you explicitly return from a
-  method inside an `ensure` block, the return will take precedence over
-  any exception being raised, and the method will return as if no
-  exception had been raised at all. In effect, the exception will be
-  silently thrown away.
+### Never return from an `ensure` block.
+If you explicitly return from a
+method inside an `ensure` block, the return will take precedence over
+any exception being raised, and the method will return as if no
+exception had been raised at all. In effect, the exception will be
+silently thrown away.
 
 ```ruby
 def foo
@@ -709,8 +708,7 @@ rescue
 end
 ```
 
-### Mitigate the proliferation of `begin` blocks by using
-  *contingency methods* (a term coined by Avdi Grimm).
+### Mitigate the proliferation of `begin` blocks by using *contingency methods* (a term coined by Avdi Grimm).
 
 ```ruby
 # bad
@@ -770,8 +768,7 @@ else
 end
 ```
 
-### Avoid rescuing the `Exception` class.  This will trap signals and calls to
-  `exit`, requiring you to `kill -9` the process.
+### Avoid rescuing the `Exception` class.  This will trap signals and calls to `exit`, requiring you to `kill -9` the process.
 
 ```ruby
 # bad
@@ -800,8 +797,7 @@ rescue StandardError => e
 end
 ```
 
-### Put more specific exceptions higher up the rescue chain, otherwise
-  they'll never be rescued from.
+### Put more specific exceptions higher up the rescue chain, otherwise they'll never be rescued from.
 
 ```ruby
 # bad
@@ -823,8 +819,7 @@ rescue Exception => e
 end
 ```
 
-### Release external resources obtained by your program in an ensure
-block.
+### Release external resources obtained by your program in an ensure block.
 
 ```ruby
 f = File.open('testfile')
@@ -837,19 +832,19 @@ ensure
 end
 ```
 
-### Use exceptions from the standard library for simple cases so you can avoid
-introducing new exception classes.
+### Use exceptions from the standard library for simple cases so you can avoid introducing new exception classes.
 
 ## Collections
 
-### Use `Set` instead of `Array` when dealing with unique elements. `Set`
-  implements a collection of unordered values with no duplicates. This
-  is a hybrid of `Array`'s intuitive inter-operation facilities and
-  `Hash`'s fast lookup.
+### Use `Set` instead of `Array` when dealing with unique elements.
+`Set` implements a collection of unordered values with no duplicates. This
+is a hybrid of `Array`'s intuitive inter-operation facilities and
+`Hash`'s fast lookup.
 
 ### Avoid the use of mutable object as hash keys.
 
 ### Rely on the fact that hashes in 1.9 are ordered.
+
 ### Never modify a collection while traversing it.
 
 ## Strings
@@ -864,15 +859,14 @@ email_with_name = user.name + ' <' + user.email + '>'
 email_with_name = "#{user.name} <#{user.email}>"
 ```
 
-### Consider padding string interpolation code with space. It more clearly sets the
-  code apart from the string.
+### Consider padding string interpolation code with space. It more clearly sets the code apart from the string.
 
 ```ruby
 "#{ user.last_name }, #{ user.first_name }"
 ```
 
-### `String#<<` performs better by mutating the string in place.  `String#+`, avoids mutation (which is good
-  in a functional way) but therefore runs slower since it creates a new string object.
+### `String#<<` performs better by mutating the string in place.
+`String#+`, avoids mutation (which is good in a functional way) but therefore runs slower since it creates a new string object.
 
 ```ruby
 # faster
@@ -910,7 +904,7 @@ if command['quit']
   ...
 end
 ```
-  
+
 ### For simple constructions you can use regexp directly through string index.
 
 ```ruby
@@ -919,8 +913,7 @@ first_group = string[/text(grp)/, 1] # get content of captured group
 string[/text (grp)/, 1] = 'replace'  # string => 'text replace'
 ```
 
-### Avoid using $1-9 as it can be hard to track what they contain and they live globally. Numbered indexes
-  or named groups can be used instead.
+### Avoid using $1-9 as it can be hard to track what they contain and they live globally. Numbered indexes or named groups can be used instead.
 
 ```ruby
 # bad
@@ -939,10 +932,8 @@ setup_connection(protocol)
 setup_connection(protocol)
 ```
 
-### Be careful not to use `^` and `$` for anchors (like in other languages) because in
-  Ruby they also match newlines.
-  For anchors, use `\A` and `\z` (not to be
-  confused with `\Z` which is the equivalent of `/\n?\z/`).
+### Be careful not to use `^` and `$` for anchors (like in other languages) because in Ruby they also match newlines.
+For anchors, use `\A` and `\z` (not to be confused with `\Z` which is the equivalent of `/\n?\z/`).
 
 ```ruby
 string = "some injection\nusername"
@@ -950,8 +941,8 @@ string[/^username$/]   # matches
 string[/\Ausername\z/] # don't match
 ```
 
-### Use `x` modifier for complex regexps so that you can use whitespace and comments to
-  make them more readable. Just be careful as spaces are ignored.
+### Use `x` modifier for complex regexps so that you can use whitespace and comments to make them more readable.
+Just be careful as spaces are ignored.
 
 ```ruby
 regexp = %r{
@@ -967,11 +958,12 @@ regexp = %r{
 
 ## Metaprogramming
 
-### Only use metaprogramming when necessary.  For example, `deliver_<mail_message>` in TMail was completely
-  unnecessary since it was equivalent to simply `deliver(:mail_message)`.
+### Only use metaprogramming when necessary.
+For example, `deliver_<mail_message>` in TMail was completely
+unnecessary since it was equivalent to simply `deliver(:mail_message)`.
 
-### Do not monkey patch core classes unless you really need to change their behavior
-  generally across all code in the process including other gems and libraries (separation of concerns!):
+### Do not monkey patch core classes unless you really need to change their behavior.
+Generally across all code in the process including other gems and libraries (separation of concerns!):
 
 ```ruby
 # bad
@@ -991,7 +983,9 @@ class_eval 'def use_relative_model_naming?; true; end', __FILE__, __LINE__
 
   - `define_method` is preferable to `class_eval { def ... }`
 
-### Avoid `method_missing` if possible. Backtraces become messy; the behavior is not listed in `#methods`; misspelled method calls might silently work (`nukes.launch_state = false`). Consider using delegation, proxy, or `define_method` instead.  If you must, use `method_missing`,
+### Avoid `method_missing` if possible.
+Backtraces become messy; the behavior is not listed in `#methods`; misspelled method calls might silently work (`nukes.launch_state = false`).
+Consider using delegation, proxy, or `define_method` instead.  If you must, use `method_missing`,
   - be sure to [also define `respond_to_missing?`](http://blog.marc-andre.ca/2010/11/methodmissing-politely.html)
   - only catch methods with a well-defined prefix, such as `find_by_*` -- make your code as assertive as possible.
   - call `super` at the end of your statement
@@ -1022,70 +1016,77 @@ end
 ## Misc
 
 ### Write `ruby -w` safe code when practical.
-### When code patterns are repeated, use separate lines and extra whitespace when practical to align columns
-  so that the code is tabular.  This makes the patterns obvious which helps to spot/prevent bugs.
+Try an editor that will show you these when you save.
+
+### When code patterns are repeated, use separate lines and extra whitespace when practical to align columns so that the code is tabular.
+This makes the patterns obvious which helps to spot/prevent bugs.
 
 ```ruby
 # bad
-    PROMOTIONAL_METHODS = [
-                    [ 'review_site', 'Content / Review Site'],
-                    [ 'coupon_site', 'Discount / Coupon Site' ],
-                    [ 'display', 'Display' ],
-                    [ 'email', 'Email' ],
-                    [ 'rewards', 'Rewards / Incentive' ],
-                    [ 'leads', 'Lead Form / Co Reg' ],
-                    [ 'search', 'Search' ],
-                    [ 'social_media', 'Social Media' ],
-                    [ 'software', 'Software' ],
-                    [ 'other', 'Other' ]
-                  ],
-    ...
-    # good
-      PROMOTIONAL_METHODS = [
-                    [ 'review_site',  'Content / Review Site'],
-                    [ 'coupon_site',  'Discount / Coupon Site' ],
-                    [ 'display',      'Display' ],
-                    [ 'email',        'Email' ],
-                    [ 'rewards',      'Rewards / Incentive' ],
-                    [ 'leads',        'Lead Form / Co Reg' ],
-                    [ 'search',       'Search' ],
-                    [ 'social_media', 'Social Media' ],
-                    [ 'software',     'Software' ],
-                    [ 'other',        'Other' ]
-                  ],
-    ...
-    # bad
-          params = {
-            'phone' => calling_phone_number.to_param,
-            'LastName' => last_name,
-            'FirstName' => first_name,
-            'Address' => primary_address,
-            'ApartmentNum' => secondary_address,
-            'City' => city_name,
-            'State' => state,
-            'Zipcode' => zip
-          }
-    ...
-    # good
-          params = {
-            'phone'         => calling_phone_number.to_param,
-            'LastName'      => last_name,
-            'FirstName'     => first_name,
-            'Address'       => primary_address,
-            'ApartmentNum'  => secondary_address,
-            'City'          => city_name,
-            'State'         => state,
-            'Zipcode'       => zip
-          }
-
+PROMOTIONAL_METHODS = [
+                [ 'review_site', 'Content / Review Site'],
+                [ 'coupon_site', 'Discount / Coupon Site' ],
+                [ 'display', 'Display' ],
+                [ 'email', 'Email' ],
+                [ 'rewards', 'Rewards / Incentive' ],
+                [ 'leads', 'Lead Form / Co Reg' ],
+                [ 'search', 'Search' ],
+                [ 'social_media', 'Social Media' ],
+                [ 'software', 'Software' ],
+                [ 'other', 'Other' ]
+              ],
+...
+# good
+  PROMOTIONAL_METHODS = [
+                [ 'review_site',  'Content / Review Site'],
+                [ 'coupon_site',  'Discount / Coupon Site' ],
+                [ 'display',      'Display' ],
+                [ 'email',        'Email' ],
+                [ 'rewards',      'Rewards / Incentive' ],
+                [ 'leads',        'Lead Form / Co Reg' ],
+                [ 'search',       'Search' ],
+                [ 'social_media', 'Social Media' ],
+                [ 'software',     'Software' ],
+                [ 'other',        'Other' ]
+              ],
+...
+# bad
+      params = {
+        'phone' => calling_phone_number.to_param,
+        'LastName' => last_name,
+        'FirstName' => first_name,
+        'Address' => primary_address,
+        'ApartmentNum' => secondary_address,
+        'City' => city_name,
+        'State' => state,
+        'Zipcode' => zip
+      }
+...
+# good
+      params = {
+        'phone'         => calling_phone_number.to_param,
+        'LastName'      => last_name,
+        'FirstName'     => first_name,
+        'Address'       => primary_address,
+        'ApartmentNum'  => secondary_address,
+        'City'          => city_name,
+        'State'         => state,
+        'Zipcode'       => zip
+      }
 ```
- 
-### Prefer code written in the functional style:  avoid side-effects like object mutation unless required by performance concerns.
-  Mutating arguments is a side-effect so don't do it unless that is the sole purpose of the method.
+
+### Prefer code written in the functional style
+avoid side-effects like object mutation unless required by performance concerns.
+ Mutating arguments is a side-effect so don't do it unless that is the sole purpose of the method.
 * Don't put required parameters into options hashes.
-### Try to keep methods to 10 lines of code or less. Ideally, most methods will be shorter than
-  5 lines of code. Comments and empty lines do not count.
+
+### Try to keep methods to 10 lines of code or less.
+Ideally, most methods will be shorter than 5 lines of code. Comments and empty lines do not count.
+
 ### Try to keep parameter lists limited to three or four parameters.
+
 ### Avoid `alias` when `alias_method` will do.
+
 ### Use `OptionParser` for parsing complex command line options and
 `ruby -s` for trivial command line options.
+

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
 
 ## Source Code Layout
 
-* Use two **spaces** per indentation level. No tabs.
+* Use two **spaces** per indentation level. No hard tabs.
 
     ```Ruby
     # good
@@ -1069,8 +1069,8 @@ introducing new exception classes.
 
     ```
  
-* Code in a functional way, avoiding mutation and other side-effects unless performance concerns require them.
-  Mutating arguments is a side-effect so don't do it unless that is the purpose of the method.
+* Prefer code written in the functional style:  avoid side-effects like object mutation unless required by performance concerns.
+  Mutating arguments is a side-effect so don't do it unless that is the sole purpose of the method.
 * Don't put required parameters into options hashes.
 * Try to keep methods to 10 lines of code or less. Ideally, most methods will be shorter than
   5 lines of code. Comments and empty lines do not count.

--- a/README.md
+++ b/README.md
@@ -573,11 +573,14 @@ hash = { one: 1, two: 2 }
 ```
 
 ### `->` / `lambda` are preferred over `proc`/`Proc.new`.
+
 This is because `lambda`s enforce argument list cardinality and have unsurprising `return` semantics.
 (Only use `proc` if you really need a return statement that returns from the enclosing code.)
 More details [here](http://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Method_Calls#Understanding_blocks.2C_Procs_and_methods).
 
-### Ruby 1.9 `->` (stabby lambda) syntax is preferred when there are arguments, since stabby lambda arguments are treated just like regular method arguments. For example, these special arguments work for stabby lambda but not `lambda` or `Proc.new`:
+### Ruby 1.9 `->` (stabby lambda) syntax is preferred when there are arguments.
+
+This is because stabby lambda arguments are treated just like regular method arguments. For example, these special arguments work for stabby lambda but not `lambda` or `Proc.new`:
 * default arguments
 * keyword arguments
 * block (`&`) argument

--- a/README.md
+++ b/README.md
@@ -211,20 +211,6 @@ else
 end
 ```
 
-### Never use `if x: ...` - it is removed in Ruby 1.9.
-Use multi-line if or the ternary operator instead.
-
-```ruby
-# bad
-result = if some_condition: something else something_else end
-
-# good
-result = some_condition ? something : something_else
-```
-
-### Use `when x then ...` for one-line cases.
-The alternative syntax `when x: ...` is removed in Ruby 1.9.
-
 ### Use `&&/||` for boolean expressions, `and/or` for control flow.
 
 ```ruby
@@ -578,7 +564,7 @@ This is because `lambda`s enforce argument list cardinality and have unsurprisin
 (Only use `proc` if you really need a return statement that returns from the enclosing code.)
 More details [here](http://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Method_Calls#Understanding_blocks.2C_Procs_and_methods).
 
-### Ruby 1.9 `->` (stabby lambda) syntax is preferred when there are arguments.
+### `->` (stabby lambda) syntax is preferred when there are arguments.
 
 This is because stabby lambda arguments are treated just like regular method arguments. For example, these special arguments work for stabby lambda but not `lambda` or `Proc.new`:
 * default arguments

--- a/README.md
+++ b/README.md
@@ -569,6 +569,7 @@ would happen if the current value happened to be `false`.)
 
 * Prefer
   * `map` over `collect`
+  * `reduce` over `inject`
   * `find` over `detect`
   * `select` over `find_all`
   * `size` over `length`

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ raise ArgumentError, "name must be provided" unless name.present?
 name.present? or raise ArgumentError, "name must be provided"
 
 # good -- the unless is a rare footnote
-formt(page) unless page.already_formatted?
+format(page) unless page.already_formatted?
 
 # good -- the if is almost always true
 send_notification(users) if users.any?

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Prelude
-RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ruby-style-guide.
+Invoca Ruby Style Guide initially forked from https://github.com/bbatsov/ruby-style-guide.
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -886,6 +886,9 @@ is a hybrid of `Array`'s intuitive inter-operation facilities and
 
 ### Never modify a collection while traversing it.
 
+### Don't use the `%w()` syntax for defining arrays
+Define them as `['a', 'b']` or `'a b'.split(' ')` 
+
 ## Strings
 
 ### Prefer string interpolation instead of string concatenation:

--- a/README.md
+++ b/README.md
@@ -32,15 +32,13 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     end
     ```
 
-* Use spaces around operators, after commas, colons and semicolons, around `{`
-  and before `}`. Whitespace might be (mostly) irrelevant to the Ruby
-  interpreter, but its proper use is the key to writing easily
-  readable code.
+* Use spaces around operators and `=>`, after commas, colons and semicolons, around `{`
+  and before `}`.
 
     ```Ruby
-    sum = 1 + 2
-    a, b = 1, 2
-    1 > 2 ? true : false; puts 'Hi'
+    a, b = 1, 2 + 3
+    location = { :city => 'Santa Barbara', :state => 'CA' }
+    size > 10 ? 'large' : 'small'
     [1, 2, 3].each { |e| puts e }
     ```
 
@@ -1012,8 +1010,66 @@ introducing new exception classes.
 
 ## Misc
 
-* Write `ruby -w` safe code.
-* Code in a functional way, avoiding mutation and other side-effects unless performance concerns require the side-effects.
+* Write `ruby -w` safe code when practical.
+* When code patterns are repeated, use separate lines and extra whitespace when practical to align columns
+  so that the code is tabular.  This makes the patterns obvious which helps to spot/prevent bugs.
+
+    ```ruby
+    # bad
+    PROMOTIONAL_METHODS = [
+                    [ 'review_site', 'Content / Review Site'],
+                    [ 'coupon_site', 'Discount / Coupon Site' ],
+                    [ 'display', 'Display' ],
+                    [ 'email', 'Email' ],
+                    [ 'rewards', 'Rewards / Incentive' ],
+                    [ 'leads', 'Lead Form / Co Reg' ],
+                    [ 'search', 'Search' ],
+                    [ 'social_media', 'Social Media' ],
+                    [ 'software', 'Software' ],
+                    [ 'other', 'Other' ]
+                  ],
+    ...
+    # good
+      PROMOTIONAL_METHODS = [
+                    [ 'review_site',  'Content / Review Site'],
+                    [ 'coupon_site',  'Discount / Coupon Site' ],
+                    [ 'display',      'Display' ],
+                    [ 'email',        'Email' ],
+                    [ 'rewards',      'Rewards / Incentive' ],
+                    [ 'leads',        'Lead Form / Co Reg' ],
+                    [ 'search',       'Search' ],
+                    [ 'social_media', 'Social Media' ],
+                    [ 'software',     'Software' ],
+                    [ 'other',        'Other' ]
+                  ],
+    ...
+    # bad
+          params = {
+            'phone' => calling_phone_number.to_param,
+            'LastName' => last_name,
+            'FirstName' => first_name,
+            'Address' => primary_address,
+            'ApartmentNum' => secondary_address,
+            'City' => city_name,
+            'State' => state,
+            'Zipcode' => zip
+          }
+    ...
+    # good
+          params = {
+            'phone'         => calling_phone_number.to_param,
+            'LastName'      => last_name,
+            'FirstName'     => first_name,
+            'Address'       => primary_address,
+            'ApartmentNum'  => secondary_address,
+            'City'          => city_name,
+            'State'         => state,
+            'Zipcode'       => zip
+          }
+
+    ```
+ 
+* Code in a functional way, avoiding mutation and other side-effects unless performance concerns require them.
   Mutating arguments is a side-effect so don't do it unless that is the purpose of the method.
 * Don't put required parameters into options hashes.
 * Try to keep methods to 10 lines of code or less. Ideally, most methods will be shorter than

--- a/README.md
+++ b/README.md
@@ -834,6 +834,8 @@ end
 
 ### Use exceptions from the standard library for simple cases so you can avoid introducing new exception classes.
 
+### If you create a custom exception class, always inherit from `StandardError` not `Exception`
+
 ## Collections
 
 ### Use `Set` instead of `Array` when dealing with unique elements.


### PR DESCRIPTION
Bad
```
collection
.transformA { ... }
.transformB { ... }
```
Good
```
collection
  .transformA { ... }
  .transformB { ... }
```