### PR TITLE
Add `when` description/example to `no-then` rule

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1081,7 +1081,7 @@ elem # => NameError: undefined local variable or method `elem'
 
 === No `then` [[no-then]]
 
-Do not use `then` for multi-line `if`/`unless`.
+Do not use `then` for multi-line `if`/`unless`/`when`.
 
 [source,ruby]
 ----
@@ -1090,8 +1090,20 @@ if some_condition then
   # body omitted
 end
 
+# bad
+case foo
+when bar then
+  # body omitted
+end
+
 # good
 if some_condition
+  # body omitted
+end
+
+# good
+case foo
+when bar
   # body omitted
 end
 ----


### PR DESCRIPTION
There's a PR to add a cop named `MultilineWhenThen`,
which detects `then` in multiline `when`.
https://github.com/rubocop-hq/rubocop/pull/7114
It refers to `MultilineIfThen` cop, which is based on `no-then` rule here.
So this commit adds `when` description and example to `no-then` rule,
making newly added `MultilineWhenThen` cop based on the style guide.
FYI, the discussion about this feature is here: https://github.com/rubocop-hq/rubocop/issues/7064