### PR TITLE
Use https for creativecommons image

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4785,7 +4785,7 @@ It's easy, just follow the contribution guidelines below:
 
 == License
 
-image:http://i.creativecommons.org/l/by/3.0/88x31.png[Creative Commons License] This work is licensed under a http://creativecommons.org/licenses/by/3.0/deed.en_US[Creative Commons Attribution 3.0 Unported License]
+image:https://i.creativecommons.org/l/by/3.0/88x31.png[Creative Commons License] This work is licensed under a http://creativecommons.org/licenses/by/3.0/deed.en_US[Creative Commons Attribution 3.0 Unported License]
 
 == Spread the Word
 


### PR DESCRIPTION
Fix SSL error on https://rubystyle.guide/

<img width="367" alt="Screenshot 2019-06-12 at 5 11 27 PM" src="https://user-images.githubusercontent.com/980783/59348618-32687380-8d35-11e9-9d27-e072520ac43c.png">
