### PR TITLE
Update a style guide for "Float Division"

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3844,17 +3844,17 @@ rand(1..6)
 
 === Float Division [[float-division]]
 
-When performing float-division on two integers, either use `fdiv` or convert the left-side integer (receiver) to float.
+When performing float-division on two integers, either use `fdiv` or convert one-side integer to float.
 
 [source,ruby]
 ----
 # bad
-a / b.to_f
 a.to_f / b.to_f
 
 # good
-a.fdiv(b)
 a.to_f / b
+a / b.to_f
+a.fdiv(b)
 ----
 
 == Strings


### PR DESCRIPTION
This PR updates a style guide for "Float Division".
The original issue for which this style was proposed.
https://github.com/rubocop-hq/ruby-style-guide/issues/628

It is an update based on the following argument.
https://github.com/rubocop-hq/rubocop/pull/7153#discussion_r295080040

The following is a quote from the argument about the reason for this change.

> I wanted to show the following option to make a bad case only when both have `to_f`.
>
> ```ruby
> # bad
> a.to_f / b.to_f
>
> # good
> a.to_f / b
> a / b.to_f
> a.fdiv(b)
> ```
>
> Whether `to_f` is used on the left or right depends on the nature of `a`
> or `b` parameter. On the other hand, it is redundant that `to_f` is used
> in both. At that time, I think it is better to let users choose whether
> to remove the left side `to_f` or the right side `to_f`. This is the
> reason I recommend this option to default.
