### PR TITLE
Introduce a reference .editorconfig file

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4859,6 +4859,57 @@ TIP: RuboCop's cops (code checks) have links to the guidelines that they are bas
 
 http://www.jetbrains.com/ruby/[RubyMine]'s code inspections are http://confluence.jetbrains.com/display/RUBYDEV/RubyMine+Inspections[partially based] on this guide.
 
+=== EditorConfig
+
+EditorConfig helps maintain consistent coding styles for multiple
+developers working on the same project across various editors and IDEs.
+The EditorConfig project consists of a file format for defining coding
+styles and a collection of text editor plugins that enable editors to
+read the file format and adhere to defined styles. EditorConfig files
+are easily readable and they work nicely with version control systems.
+
+A possible EditorConfig file that reflects this guide is:
+
+[source]
+----
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# top-most EditorConfig file
+root = true
+
+# Let's encode the whole world with UTF-8
+charset = utf-8
+end_of_line = lf
+
+# Due to RFC 678, RFC 2046, RFC 2646, ... the indent style uses spaces.
+indent_style = space
+
+# with a newline ending every file (see POSIX standard)
+insert_final_newline = true
+
+# Maximum 72 characters per line (see RFC 678, RFC 2046, RFC 2646, ...)
+max_line_length = 72
+
+# Hor. tab is set to 8 characters (see RFC 678, RFC 2046, RFC 2646, ...)
+tab_width = 8
+
+# Remove all trailing whitespaces from files
+trim_trailing_whitespace = true
+
+[*.rb]
+indent_size = 2
+
+[*.md]
+# Four spaces are defined as the unit of indentation.
+indent_size = 4
+
+[*.json]
+indent_size = 4
+----
+
 == History
 
 This guide started its life as an internal company Ruby coding guidelines (written by https://github.com/bbatsov[Bozhidar Batsov]).


### PR DESCRIPTION
This patch adds a simple EditorConfig file as reference for the Ruby style guide.

See https://editorconfig.org/ for more details: EditorConfig helps maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs. The EditorConfig project consists of a file format for defining coding styles and a collection of text editor plugins that enable editors to read the file format and adhere to defined styles. EditorConfig files are easily readable and they work nicely with version control systems.