### PR TITLE
Reintroduce typo in method_missing example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4515,7 +4515,7 @@ end
 
 === No `method_missing` [[no-method-missing]]
 
-Avoid using `method_missing` for metaprogramming because backtraces become messy, the behavior is not listed in `#methods`, and misspelled method calls might silently work, e.g. `nukes.launch_state = false`.
+Avoid using `method_missing` for metaprogramming because backtraces become messy, the behavior is not listed in `#methods`, and misspelled method calls might silently work, e.g. `nukes.luanch_state = false`.
 Consider using delegation, proxy, or `define_method` instead.
 If you must use `method_missing`:
 


### PR DESCRIPTION
I quoted the example of `method_missing` in a presentation I gave a few months ago. I was looking at the example again today and realised that it actually doesn't make sense. The example talks about misspelled methods working. However, it actually contains no misspelled method. Tracing the history I see that the typo was 'fixed' in 28f6993d26a0ee8f9fa5c8eddf2a5840b747186b. 

To once again properly illustrate the point that the original author tried to make this PR re-introduces the typo.