### PR TITLE
[Fix #763] Add rule suggesting not to use RUBY_VERSION in gemspec

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4644,6 +4644,31 @@ https://ruby-doc.com/docs/ProgrammingRuby/html/rdtool.html[here].
 RD predated the rise of RDoc and YARD and was effectively obsoleted by them.footnote:[According to this https://en.wikipedia.org/wiki/Ruby_Document_format[Wikipedia article] the format used to be popular until the early 2000s when it was superseded by RDoc.]
 ****
 
+== Gemfile and Gemspec
+
+=== No `RUBY_VERSION` in the gemspec [[no-ruby-version-gemspec]]
+
+The gemspec should not contain `RUBY_VERSION` as a condition to switch dependencies.
+`RUBY_VERSION` is determined by `rake release`, so users may end up with wrong dependency.
+
+[source,ruby]
+----
+# bad
+Gem::Specification.new do |s|
+  if RUBY_VERSION >= '2.5'
+    s.add_runtime_dependency 'gem_a'
+  else
+    s.add_runtime_dependency 'gem_b'
+  end
+end
+----
+
+Fix by either:
+
+* Post-install messages.
+* Add both gems as dependency (if permissible).
+* If development dependencies, move to Gemfile.
+
 == Misc
 
 === No Flip-flops [[no-flip-flops]]


### PR DESCRIPTION
Closes https://github.com/rubocop-hq/ruby-style-guide/issues/763