### PR TITLE
Fix typo and minor formatting

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3599,7 +3599,7 @@ hash = { :one => 1, :two => 2, :three => 3 }
 hash = { one: 1, two: 2, three: 3 }
 ----
 
-=== No Mixed Hash Syntaces [[no-mixed-hash-syntaces]]
+=== No Mixed Hash Syntaxes [[no-mixed-hash-syntaxes]]
 
 Don't mix the Ruby 1.9 hash syntax with hash rockets in the same hash literal.
 When you've got keys that are not symbols stick to the hash rockets syntax.

--- a/README.adoc
+++ b/README.adoc
@@ -1159,7 +1159,7 @@ else
 end
 ----
 
-=== No Semicolon `if`s [[no-semicolon-ifs]]
+=== No Semicolon `if` [[no-semicolon-if]]
 
 Do not use `if x; ...`. Use the ternary operator instead.
 


### PR DESCRIPTION
Fixes #773.

Also, currently `if`s in "No semicolon `if`s" do not render the code block for `if`. I removed the 's' in order to allow it.

