### PR TITLE
Add rule stating control flow keywords should begin their line

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1052,6 +1052,19 @@ end
 
 == Flow of Control
 
+=== Control Flow Keywords [[control-flow-keywords]]
+
+Keywords that alter control flow, e.g. `next`, `raise`, `return`, etc. should appear at the beginning of the line.
+
+[source,ruby]
+----
+# bad
+makes_sense? ? "Great success!" : raise("Woah.")
+
+# good
+raise("Woah.") unless makes_sense?
+----
+
 === No `for` Loops [[no-for-loops]]
 
 Do not use `for`, unless you know exactly why.


### PR DESCRIPTION
### Rationale

Breaking control flow is almost certainly the most significant thing that is going on in that line of code, and so it deserves the most prominent spot, at the beginning of the line.

Hiding away control flow in the middle of a long line makes it unnecessarily hard to parse, and Ruby gives us a slew of forms in which we can rewrite the line with the change in flow emphasized.