### PR TITLE
Fix Explicit `self` example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1561,7 +1561,7 @@ end
 def ready?
   if last_reviewed_at > last_updated_at
     worker.update(content, options)
-    status = :in_progress
+    self.status = :in_progress
   end
   status == :verified
 end


### PR DESCRIPTION
I believe that `self` was avoided too much in the example and its previous version contradicted the rule description above.