### PR TITLE
Add "No mix named and numbered captures" rule

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4336,24 +4336,32 @@ Use non-capturing groups when you don't use the captured result.
 /(?:first|second)/
 ----
 
-=== No mix named and numbered captures [[no-mix-named-and-numbered-captures]]
+=== Do not mix named and numbered captures [[do-not-mix-named-and-numbered-captures]]
 
 Do not mix named captures and numbered captures in a Regexp literal.
 Because numbered capture is ignored if they're mixed.
 
 [source,ruby]
 ----
-# bad
-/(?<foo>FOO)(BAR)/
+# bad - There is no way to access `(BAR)` capturing.
+m = /(?<foo>FOO)(BAR)/.match('FOOBAR')
+p m[:foo] # => "FOO"
+p m[1]    # => "FOO"
+p m[2]    # => nil   - not "BAR"
 
-# good
-/(?<foo>FOO)(?<bar>BAR)/
+# good - Both captures are accessible with names.
+m = /(?<foo>FOO)(?<bar>BAR)/.match('FOOBAR')
+p m[:foo] # => "FOO"
+p m[:bar] # => "BAR"
 
-# good
-/(?<foo>FOO)(?:BAR)/
+# good - `(?:BAR)` is non-capturing grouping.
+m = /(?<foo>FOO)(?:BAR)/.match('FOOBAR')
+p m[:foo] # => "FOO"
 
-# good
-/(FOO)(BAR)/
+# good - Both captures are accessible with numbers.
+m = /(FOO)(BAR)/.match('FOOBAR')
+p m[1] # => "FOO"
+p m[2] # => "BAR"
 ----
 
 === No Perl Regexp Last Matchers [[no-perl-regexp-last-matchers]]

--- a/README.adoc
+++ b/README.adoc
@@ -4336,6 +4336,26 @@ Use non-capturing groups when you don't use the captured result.
 /(?:first|second)/
 ----
 
+=== No mix named and numbered captures [[no-mix-named-and-numbered-captures]]
+
+Do not mix named captures and numbered captures in a Regexp literal.
+Because numbered capture is ignored if they're mixed.
+
+[source,ruby]
+----
+# bad
+/(?<foo>FOO)(BAR)/
+
+# good
+/(?<foo>FOO)(?<bar>BAR)/
+
+# good
+/(?<foo>FOO)(?:BAR)/
+
+# good
+/(FOO)(BAR)/
+----
+
 === No Perl Regexp Last Matchers [[no-perl-regexp-last-matchers]]
 
 Don't use the cryptic Perl-legacy variables denoting last regexp group matches (`$1`, `$2`, etc).


### PR DESCRIPTION
I created Lint/MixedRegexpCaptureTypes cop in rubocop-hq/rubocop#7749.
This pull request adds a mention of the problem to the style guide also.



