### PR TITLE
Fix broken link within quote attribute

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3356,7 +3356,7 @@ An outdated comment is worse than no comment at all.
 
 === Refactor, Don't Comment [[refactor-dont-comment]]
 
-[quote, old programmers maxim, through http://eloquentruby.com/blog/2011/03/07/good-code-and-good-jokes/[Russ Olsen]]
+[quote, old programmers maxim, 'http://eloquentruby.com/blog/2011/03/07/good-code-and-good-jokes/[through Russ Olsen]']
 ____
 Good code is like a good joke: it needs no explanation.
 ____


### PR DESCRIPTION
This change fixes a broken link within a quote attribute. I am using the style outlined in the asciidoc docs under [ Attribute value substitution](http://asciidoc.org/userguide.html#X79).