### PR TITLE
Refine an example for "Suppressing Exceptions" rule

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1813,12 +1813,25 @@ Don't suppress exceptions.
 ----
 # bad
 begin
-  # an exception occurs here
+  do_something # an exception occurs here
 rescue SomeError
-  # the rescue clause does absolutely nothing
 end
 
-# bad
+# good
+begin
+  do_something # an exception occurs here
+rescue SomeError
+  handle_exception
+end
+
+# good
+begin
+  do_something # an exception occurs here
+rescue SomeError
+  # Notes on why exception handling is not performed
+end
+
+# good
 do_something rescue nil
 ----
 


### PR DESCRIPTION
Follow up of https://github.com/rubocop-hq/rubocop/pull/7805#issuecomment-601071106.

This PR refines an example for "Suppressing Exceptions" rule.

And `do_something rescue nil` will be changed from bad case to good case based on RuboCop (0.81)'s behavior and the comment below.
https://github.com/rubocop-hq/rubocop/pull/7297#issuecomment-523501395