### PR TITLE
Fix typo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3987,7 +3987,7 @@ One could favor the alternative engineering notation, in which the exponent must
 3e3
 1.17e6
 3.14
----
+----
 
 Alternative : engineering notation:
 


### PR DESCRIPTION
Accidentally forgot a dash in https://github.com/rubocop-hq/ruby-style-guide/pull/811, which breaks the formatting in https://github.com/rubocop-hq/ruby-style-guide#exponential-notation