### PR TITLE
Refine an example for "Space in Method Calls" rule

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -723,10 +723,10 @@ Do not put a space between a method name and the opening parenthesis.
 [source,ruby]
 ----
 # bad
-f (3 + 2) + 1
+puts (x + y)
 
 # good
-f(3 + 2) + 1
+puts(x + y)
 ----
 
 === Multi-line Arrays Alignment [[align-multiline-arrays]]


### PR DESCRIPTION
Follow up of https://github.com/rubocop-hq/rubocop/pull/7909.

This PR refines an example for "Space in Method Calls" rule.

The example code is not compatible.

```ruby
def f(num)
  num * 2
end

p f (3 + 2) + 1 #=> 12
p f(3 + 2) + 1  #=> 11
```

This PR replaces an example code.