### PR TITLE
Refine examples for "Empty Lines around Access Modifier" rule

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -486,19 +486,18 @@ Use empty lines around access modifiers.
 ----
 # bad
 class Foo
-  attr_reader :foo
-  def foo
-    # do something...
-  end
+  def bar; end
+  private
+  def baz; end
 end
 
 # good
 class Foo
-  attr_reader :foo
+  def bar; end
 
-  def foo
-    # do something...
-  end
+  private
+
+  def baz; end
 end
 ----
 


### PR DESCRIPTION
This rule is referenced by `Layout/EmptyLinesAroundAccessModifier` cop.
https://docs.rubocop.org/en/stable/cops_layout/#layoutemptylinesaroundaccessmodifier

However the rule's example code is different from the explanation and cop's behaviour.
This PR updates the rule's example based on `Layout/EmptyLinesAroundAccessModifier` cop's example.

For the original example, I will open a PR as a new rule.