### PR TITLE
Add new "Empty Lines around Attribute Accessor" rule

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -478,9 +478,9 @@ some_method
 some_method
 ----
 
-=== Empty Lines around Access Modifier [[empty-lines-around-access-modifier]]
+=== Empty Lines around Attribute Accessor [[empty-lines-around-attribute-accessor]]
 
-Use empty lines around access modifiers.
+Use empty lines around attribute accessor.
 
 [source,ruby]
 ----


### PR DESCRIPTION
Follow up to #816.
This PR adds new "Empty Lines around Attribute Accessor" rule. It will update the existing example with the new rule name.