### PR TITLE
More clear (?) example for Exponential Notation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4064,6 +4064,12 @@ When using exponential notation for numbers, prefer using the normalized scienti
 
 The goal is to avoid confusion between powers of ten and exponential notation, as one quickly reading `10e7` could think it's 10 to the power of 7 (one then 7 zeroes) when it's actually 10 to the power of 8 (one then 8 zeroes). If you want 10 to the power of 7, you should do `1e7`.
 
+| power notation | exponential notation | output   |
+|----------------|----------------------|----------|
+| 10 ** 7        | 1e7                  | 10000000 |
+| 10 ** 6        | 1e6                  | 1000000  |
+| 10 ** 7        | 10e6                 | 10000000 |
+
 One could favor the alternative engineering notation, in which the exponent must always be a multiple of 3 for easy conversion to the thousand / million / ... system.
 
 [source,ruby]

--- a/README.adoc
+++ b/README.adoc
@@ -4062,7 +4062,7 @@ a.fdiv(b)
 
 When using exponential notation for numbers, prefer using the normalized scientific notation, which uses a mantissa between 1 (inclusive) and 10 (exclusive). Omit the exponent altogether if it is zero.
 
-The goal is to avoid confusion between powers of ten and exponential notation, as one quickly reading `10e7` could think it's `10**7` when it's actually `10**8`.
+The goal is to avoid confusion between powers of ten and exponential notation, as one quickly reading `10e7` could think it's 10 to the power of 7 (one then 7 zeroes) when it's actually 10 to the power of 8 (one then 8 zeroes). If you want 10 to the power of 7, you should do `1e7`.
 
 One could favor the alternative engineering notation, in which the exponent must always be a multiple of 3 for easy conversion to the thousand / million / ... system.
 


### PR DESCRIPTION
The current formatting for this section looks broken:

![image](https://user-images.githubusercontent.com/509837/86158687-c2a76100-bace-11ea-94ce-cf188a0c9eee.png)
![image](https://user-images.githubusercontent.com/509837/86158694-c4712480-bace-11ea-9e5a-468d1159376a.png)

Rather than mess around with ** (which is being misread as markdown), I just spelt it out using the wording they taught me in high school math. Hopefully I remember it right...


| power notation | exponential notation | output   |
|----------------|----------------------|----------|
| 10 ** 7        | 1e7                  | 10000000 |
| 10 ** 6        | 1e6                  | 1000000  |
| 10 ** 7        | 10e6                 | 10000000 |