### PR TITLE
Add comma to Multi-line Method Chains sentence

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -672,7 +672,7 @@ There are two popular styles in the Ruby community, both of which are considered
 
 ==== Leading `.` [[leading-dot-in-multi-line-chains]]
 
-When continuing a chained method invocation on another line keep the `.` on the second line.
+When continuing a chained method invocation on another line, keep the `.` on the second line.
 
 [source,ruby]
 ----


### PR DESCRIPTION
In the Multi-line Method Chains section, the Leading and Trailing style
subsections both begin with a similar sentence, yet the sentence in the
Leading subsection does not use a comma after the introductory clause,
while the sentence in the Trailing subsection does.  Add a comma to the
Leading subsection sentence to make the two sentences consistent with
each other.