### PR TITLE
Add new "Identity Comparison" rule

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2198,6 +2198,19 @@ something = something && something.downcase
 something &&= something.downcase
 ----
 
+=== Identity Comparison [[identity-comparison]]
+
+Prefer `equal?` over `==` when comparing `object_id`. `Object#equal?` is provided to compare objects for identity, and in contrast `Object#==` is provided for the purpose of doing value comparison.
+
+[source,ruby]
+----
+# bad
+foo.object_id == bar.object_id
+
+# good
+foo.equal?(bar)
+----
+
 === Explicit Use of the Case Equality Operator [[no-case-equality]]
 
 Avoid explicit use of the case equality operator `===`.


### PR DESCRIPTION
This PR adds new "Equal Object Identifier" rule that prefers `equal?` over `==` when comparing `object_id`. `Object#equal?` method is provided to compare objects for identity, and comparing objects for equality using `Object#==` does not require
redundant `object_id` to be repeated.

```ruby
# bad
foo.object_id == bar.object_id

# good
foo.equal?(bar)
```