### PR TITLE
Add guideline for constant definitions in blocks

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3425,6 +3425,27 @@ class TestClass
 end
 ----
 
+=== Defining Constants within a Block [[no-constant-definition-in-block]]
+
+Do not define constants within a block, since the block's scope does not isolate or namespace the constant in any way.
+
+Define the constant outside of the block instead, or use a variable or method if defining the constant in the outer scope would be problematic.
+
+[source,ruby]
+----
+# bad - FILES_TO_LINT is now defined globally
+task :lint do
+  FILES_TO_LINT = Dir['lib/*.rb']
+  # ...
+end
+
+# good - files_to_lint is only defined inside the block
+task :lint do
+  files_to_lint = Dir['lib/*.rb']
+  # ...
+end
+----
+
 == Classes: Constructors
 
 === Factory Methods [[factory-methods]]


### PR DESCRIPTION
As requested in https://github.com/rubocop-hq/rubocop/pull/8707#issuecomment-691520078.