### PR TITLE
Remove architecture entries

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3111,14 +3111,6 @@ module Utilities
 end
 ----
 
-=== Liskov [[liskov]]
-
-When designing class hierarchies make sure that they conform to the https://en.wikipedia.org/wiki/Liskov_substitution_principle[Liskov Substitution Principle].
-
-=== SOLID design [[solid-design]]
-
-Try to make your classes as https://en.wikipedia.org/wiki/SOLID[SOLID] as possible.
-
 === Define `to_s` [[define-to-s]]
 
 Always supply a proper `to_s` method for classes that represent domain objects.


### PR DESCRIPTION
These are applicable to any object oriented language, and are about higher level design concepts rather than style. I think they should be removed to keep the style guide focused.