### PR TITLE
Fix Rubocop plugins broken link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5433,7 +5433,7 @@ Here are some tools to help you automatically check Ruby code against this guide
 === RuboCop
 
 https://github.com/rubocop-hq/rubocop[RuboCop] is a Ruby static code analyzer and formatter, based on this style guide.
-RuboCop already covers a significant portion of the guide and has https://docs.rubocop.org/en/stable/integration_with_other_tools/[plugins] for most popular Ruby editors and IDEs.
+RuboCop already covers a significant portion of the guide and has https://docs.rubocop.org/rubocop/integration_with_other_tools.html[plugins] for most popular Ruby editors and IDEs.
 
 TIP: RuboCop's cops (code checks) have links to the guidelines that they are based on, as part of their metadata.
 


### PR DESCRIPTION
Changes the [broken link](https://docs.rubocop.org/en/stable/integration_with_other_tools/) on RuboCop section to [updated link](https://docs.rubocop.org/rubocop/integration_with_other_tools.html).

Before the adjustment, clicking on https://docs.rubocop.org/en/stable/integration_with_other_tools/ leads to an invalid page.