### PR TITLE
Do not offend implicit `begin` guideline

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -584,6 +584,8 @@ class Foo
 
     end
 
+    true
+
   end
 
 end


### PR DESCRIPTION
A small hack to make the "bad" example only bad from the point of the described guideline.
Previously it was breaking https://github.com/rubocop-hq/ruby-style-guide#implicit-begin as well.

Fixes #697