### PR TITLE
Add guideline about omitting super arguments

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3216,6 +3216,42 @@ def some_method(&)
 end
 ----
 
+=== Super Forwarding
+
+Use `super` without arguments when the enclosing methods arguments are the same.
+
+When super is called without arguments and parentheses Ruby will automatically forward the arguments taken by the method.
+
+[source,ruby]
+----
+# bad
+def some_method(*args, **kwargs)
+  super(*args, **kwargs)
+end
+
+# good - implicitly passing all arguments
+def method(*args, **kwargs)
+  super
+end
+
+# good - forwarding a subset of the arguments
+def method(*args, **kwargs)
+  super(*args)
+end
+
+# good - calling super with different arguments
+def method(*args, **kwargs)
+  super("foo", *args, **kwards)
+end
+
+# good - forwarding no arguments
+def method(*args, **kwargs)
+  super()
+end
+----
+
+IMPORTANT: Blocks are always passed to the parent method. `&nil` can be passed to `super` if the block should remain local.
+
 === Private Global Methods [[private-global-methods]]
 
 If you really need "global" methods, add them to Kernel and make them private.


### PR DESCRIPTION
For https://github.com/rubocop/rubocop/pull/12427 which is the RuboCop implementation of this. I'll just copy the examples over:

```rb
def some_method(*args, **kwargs)
  super(*args, **kwargs)
end

# good - implicitly passing all arguments
def method(*args, **kwargs)
  super
end

# good - forwarding a subset of the arguments
def method(*args, **kwargs)
  super(*args)
end

# good - calling super with different arguments
def method(*args, **kwargs)
  super("foo", *args, **kwards)
end

# good - forwarding no arguments
def method(*args, **kwargs)
  super()
end
```

There's an interesting interaction with blocks that I wasn't previously aware of: they are just always passed, unless explicitly opted out through `&nil`. Demonstration:

```rb
class A
  def foo(*args, **kwargs)
    if block_given?
      pp yield
    else
      pp "No Block"
    end
  end
  
  def bar(...)
    if block_given?
      pp yield
    else
      pp "No Block"
    end
  end
end

class B < A
  def foo(*args, **kwargs)
    super(*args, **kwargs)
    super()
  end
  
  def bar(*args, **kwargs, &blk)
    super(*args, **kwargs, &blk)
    super()
  end
end

B.new.foo("foo", c: "c", d: "d") { "FOO" }
B.new.bar("bar", c: "c", d: "d") { "BAR" }
# => Never prints "No Block"
```

I've added a callout for this at the end.