### PR TITLE
Clarify that `can` is sometimes a valid verb for predicate names

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1047,8 +1047,10 @@ end
 
 === Predicate Methods Prefix [[bool-methods-prefix]]
 
-Avoid prefixing predicate methods with the auxiliary verbs such as `is`, `does`, or `can`.
+Avoid prefixing predicate methods with the auxiliary verbs such as `is`, `has` or `does`.
 These words are redundant and inconsistent with the style of boolean methods in the Ruby core library, such as `empty?` and `include?`.
+
+NOTE: `can` should also be avoided when possible, but is also useful when meaning "allowed to".
 
 [source,ruby]
 ----


### PR DESCRIPTION
Follows https://github.com/rubocop/rubocop/pull/14032#issuecomment-2751535006