### PR TITLE
Add guideline discouraging embedded newlines in puts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5893,6 +5893,21 @@ $stderr.puts 'This is a warning!'
 warn 'This is a warning!'
 ----
 
+=== Separate `puts` for Newlines [[puts-newlines]]
+
+Use separate `puts` calls instead of embedding newline characters (`\n`) in strings.
+This improves readability and follows Ruby conventions.
+
+[source,ruby]
+----
+# bad
+puts "\nmessage"
+
+# good
+puts
+puts 'message'
+----
+
 === `Array#join` [[array-join]]
 
 Prefer the use of `Array#join` over the fairly cryptic `Array#*` with a string argument.


### PR DESCRIPTION
**Note**: PR co-authored with Claude Code

## Summary

This PR adds a guideline discouraging the use of embedded newline characters (`\n`) in `puts` calls, in favor of using separate `puts` calls.

## Motivation

I've noticed that AI models frequently generate Ruby code using the pattern `puts "\nmessage"` when adding blank lines to output. I suspect this is due to training bias from Python codebases, where `print("\nmessage")` is an accepted and common style.

However, in Ruby, the idiomatic approach is to use separate `puts` calls:

```ruby
puts
puts 'message'
```

This is more readable and aligns better with Ruby conventions.

## Next Steps

I was intending to add a new RuboCop cop to enforce this guideline, but I wanted to open this PR here first for discussion. If the community agrees this is a worthwhile guideline, I'll proceed with implementing the corresponding cop in RuboCop.

## Changes

- Added a new section "Separate `puts` for Newlines" in the Misc section
- Provided clear examples of the discouraged and preferred patterns